### PR TITLE
fix typo in the redirect following code

### DIFF
--- a/pyroscope/remote.go
+++ b/pyroscope/remote.go
@@ -67,7 +67,7 @@ func newRemote(cfg remoteConfig, logger Logger) (*remote, error) {
 			// Don't follow redirects
 			// Since the go http client strips the Authorization header when doing redirects (eg http -> https)
 			// https://github.com/golang/go/blob/a41763539c7ad09a22720a517a28e6018ca4db0f/src/net/http/client_test.go#L1764
-			// that makes the an authorized return a 401
+			// making an authorized server return a 401
 			// which is confusing since the user most likely already set up an API Key
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
 				return http.ErrUseLastResponse


### PR DESCRIPTION
Followup from https://github.com/pyroscope-io/client/pull/9

Fix that nonsense comment (most likely I got distracted by something else and forgot to come back to it :) )