### PR TITLE
Add __session_id__ label

### DIFF
--- a/session.go
+++ b/session.go
@@ -2,6 +2,12 @@ package pyroscope
 
 import (
 	"bytes"
+	crand "crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+	"hash/fnv"
+	"math/rand"
+	"os"
 	"runtime"
 	"runtime/debug"
 	"runtime/pprof"
@@ -112,7 +118,7 @@ type flush struct {
 }
 
 func NewSession(c SessionConfig) (*Session, error) {
-	appName, err := mergeTagsWithAppName(c.AppName, c.Tags)
+	appName, err := mergeTagsWithAppName(c.AppName, newSessionID(), c.Tags)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +157,7 @@ func NewSession(c SessionConfig) (*Session, error) {
 //
 // App name may be an empty string. Tags must not contain reserved keys,
 // the map is modified in place.
-func mergeTagsWithAppName(appName string, tags map[string]string) (string, error) {
+func mergeTagsWithAppName(appName string, sid sessionID, tags map[string]string) (string, error) {
 	k, err := flameql.ParseKey(appName)
 	if err != nil {
 		return "", err
@@ -165,6 +171,7 @@ func mergeTagsWithAppName(appName string, tags map[string]string) (string, error
 		}
 		k.Add(tagKey, tagValue)
 	}
+	k.Add(sessionIDLabelName, sid.String())
 	return k.Normalized(), nil
 }
 
@@ -451,4 +458,57 @@ func numGC() uint32 {
 	var memStats runtime.MemStats
 	runtime.ReadMemStats(&memStats)
 	return memStats.NumGC
+}
+
+const sessionIDLabelName = "__session_id__"
+
+type sessionID uint64
+
+func (s sessionID) String() string {
+	var b [8]byte
+	binary.LittleEndian.PutUint64(b[:], uint64(s))
+	return hex.EncodeToString(b[:])
+}
+
+func newSessionID() sessionID { return globalSessionIDGenerator.newSessionID() }
+
+var globalSessionIDGenerator = newSessionIDGenerator()
+
+type sessionIDGenerator struct {
+	sync.Mutex
+	src *rand.Rand
+}
+
+func (gen *sessionIDGenerator) newSessionID() sessionID {
+	var b [8]byte
+	gen.Lock()
+	_, _ = gen.src.Read(b[:])
+	gen.Unlock()
+	return sessionID(binary.LittleEndian.Uint64(b[:]))
+}
+
+func newSessionIDGenerator() *sessionIDGenerator {
+	s, ok := sessionIDHostSeed()
+	if !ok {
+		s = sessionIDRandSeed()
+	}
+	return &sessionIDGenerator{src: rand.New(rand.NewSource(s))}
+}
+
+func sessionIDRandSeed() int64 {
+	var rndSeed int64
+	_ = binary.Read(crand.Reader, binary.LittleEndian, &rndSeed)
+	return rndSeed
+}
+
+var hostname = os.Hostname
+
+func sessionIDHostSeed() (int64, bool) {
+	v, err := hostname()
+	if err != nil {
+		return 0, false
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(v))
+	return int64(h.Sum64()), true
 }


### PR DESCRIPTION
Please see https://github.com/grafana/pyroscope/issues/2443.

The change adds a pseudo-random `__session_id__` label to the label set. This identifier is based on the hostname: if hostname can't be accessed, a random value is generated.

At the moment the label is not supported in the backend and is discarded in distributors. Next step is to make distributors aware of "sessions" and allow configuring cardinality limit of the label. 
