### PR TITLE
chore: relax internals stub build tag to golang 1.22

### DIFF
--- a/godeltaprof/internal/pprof/stub.go
+++ b/godeltaprof/internal/pprof/stub.go
@@ -1,5 +1,5 @@
-//go:build go1.16 && !go1.22
-// +build go1.16,!go1.22
+//go:build go1.16 && !go1.23
+// +build go1.16,!go1.23
 
 package pprof
 


### PR DESCRIPTION
# What?

Relax the internal stub build tag for golang 1.22 (which is the current tip)

# Why?

Otherwise, tests on tip could fail, and example: https://github.com/grafana/k6/actions/runs/6422397110/job/17438798642?pr=3370