### PR TITLE
fix: fix race, do not try to upload empty cpu profile

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,1 +1,0 @@
-github.com/pyroscope-io/godeltaprof v0.1.2/go.mod h1:psMITXp90+8pFenXkKIpNhrfmI9saQnPbba27VIaiQE=

--- a/session.go
+++ b/session.go
@@ -72,6 +72,7 @@ type Session struct {
 	logger    Logger
 	stopOnce  sync.Once
 	stopCh    chan struct{}
+	wg        sync.WaitGroup
 	flushCh   chan *flush
 	trieMutex sync.Mutex
 
@@ -203,7 +204,11 @@ func (ps *Session) Start() error {
 	t := ps.truncatedTime()
 	ps.reset(t, t)
 
-	go ps.takeSnapshots()
+	ps.wg.Add(1)
+	go func() {
+		defer ps.wg.Done()
+		ps.takeSnapshots()
+	}()
 	return nil
 }
 
@@ -409,6 +414,7 @@ func (ps *Session) Stop() {
 	ps.stopOnce.Do(func() {
 		// TODO: wait for stopCh consumer to finish!
 		close(ps.stopCh)
+		ps.wg.Wait()
 		// before stopping, upload the tries
 		ps.uploadLastBitOfData(time.Now())
 	})
@@ -417,6 +423,10 @@ func (ps *Session) Stop() {
 func (ps *Session) uploadLastBitOfData(now time.Time) {
 	if ps.isCPUEnabled() {
 		pprof.StopCPUProfile()
+		prof := ps.cpuBuf.Bytes()
+		if len(prof) == 0 {
+			return
+		}
 		ps.upstream.Upload(&upstream.UploadJob{
 			Name:            ps.appName,
 			StartTime:       ps.startTime,
@@ -426,7 +436,7 @@ func (ps *Session) uploadLastBitOfData(now time.Time) {
 			Units:           "samples",
 			AggregationType: "sum",
 			Format:          upstream.FormatPprof,
-			Profile:         copyBuf(ps.cpuBuf.Bytes()),
+			Profile:         copyBuf(prof),
 		})
 	}
 }


### PR DESCRIPTION
I think there is a race when the profiler is stopped. ie `uploadData`  and `uploadLastBitOfData` may be running concurrently.
This pr tries to fix the race. Also makes it not try uploading empty profiles". 

Although I failed to reproduce these problems. So this is just a guess.