### PR TITLE
fix(check_golang_profiler_changes): do not remove temp file

### DIFF
--- a/godeltaprof/compat/cmd/check_golang_profiler_changes/main.go
+++ b/godeltaprof/compat/cmd/check_golang_profiler_changes/main.go
@@ -217,7 +217,6 @@ func createTempFile(body string) string {
 	prBodyFile, err := os.CreateTemp("", "check_golang_profiler_changes")
 	requireNoError(err, "create temp file")
 	prBodyFilePath := prBodyFile.Name()
-	defer os.Remove(prBodyFilePath)
 	prBodyFile.Write([]byte(body))
 	prBodyFile.Close()
 	return prBodyFilePath


### PR DESCRIPTION
I already regret I introduced this, there should be a better way :shrug:
I hope this is is the last fix for this "check", otherwise Im probably going to remove it 