### PR TITLE
Restricts running profile changes checker for forks

### DIFF
--- a/.github/workflows/check_golang_profiler_changes.yml
+++ b/.github/workflows/check_golang_profiler_changes.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   check_golang_profiler_changes:
     runs-on: ubuntu-latest
+    if: github.repository == 'grafana/pyroscope-go' # avoid running on forks
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
# What?

This change restricts running the scheduled workflow for forks.

Based on: https://github.com/orgs/community/discussions/16109

# Why?

For the forks, this check will fail almost any time.

See an example: https://github.com/olegbespalov/pyroscope-go/actions/workflows/check_golang_profiler_changes.yml