### PR TITLE
feat: interruptible CPU collector

### DIFF
--- a/api.go
+++ b/api.go
@@ -11,22 +11,27 @@ import (
 )
 
 type Config struct {
-	ApplicationName        string // e.g backend.purchases
-	Tags                   map[string]string
-	ServerAddress          string // e.g http://pyroscope.services.internal:4040
-	AuthToken              string // specify this token when using pyroscope cloud
-	BasicAuthUser          string // http basic auth user
-	BasicAuthPassword      string // http basic auth password
-	TenantID               string // specify TenantId when using phlare multi-tenancy
-	SampleRate             uint32 // todo this one is not used
-	UploadRate             time.Duration
-	Logger                 Logger
-	ProfileTypes           []ProfileType
-	DisableGCRuns          bool // this will disable automatic runtime.GC runs between getting the heap profiles
-	DisableAutomaticResets bool // disable automatic profiler reset every 10 seconds. Reset manually by calling Flush method
-	// Deprecated: the field is ignored and does nothing
+	ApplicationName   string // e.g backend.purchases
+	Tags              map[string]string
+	ServerAddress     string // e.g http://pyroscope.services.internal:4040
+	AuthToken         string // specify this token when using pyroscope cloud
+	BasicAuthUser     string // http basic auth user
+	BasicAuthPassword string // http basic auth password
+	TenantID          string // specify TenantId when using phlare multi-tenancy
+	UploadRate        time.Duration
+	Logger            Logger
+	ProfileTypes      []ProfileType
+	DisableGCRuns     bool // this will disable automatic runtime.GC runs between getting the heap profiles
+	HTTPHeaders       map[string]string
+	// Deprecated: the field will be removed in future releases.
+	// DisableAutomaticResets is ignored.
+	DisableAutomaticResets bool
+	// Deprecated: the field will be removed in future releases.
+	// Use UploadRate instead.
 	DisableCumulativeMerge bool
-	HTTPHeaders            map[string]string
+	// Deprecated: the field will be removed in future releases.
+	// SampleRate is set to 100 and is not configurable.
+	SampleRate uint32
 }
 
 type Profiler struct {
@@ -38,9 +43,6 @@ type Profiler struct {
 func Start(cfg Config) (*Profiler, error) {
 	if len(cfg.ProfileTypes) == 0 {
 		cfg.ProfileTypes = DefaultProfileTypes
-	}
-	if cfg.SampleRate == 0 {
-		cfg.SampleRate = DefaultSampleRate
 	}
 	if cfg.Logger == nil {
 		cfg.Logger = noopLogger
@@ -68,11 +70,6 @@ func Start(cfg Config) (*Profiler, error) {
 		return nil, err
 	}
 
-	if cfg.UploadRate == 0 {
-		// For backward compatibility.
-		cfg.UploadRate = 15 * time.Second
-	}
-
 	sc := SessionConfig{
 		Upstream:               uploader,
 		Logger:                 cfg.Logger,
@@ -81,17 +78,9 @@ func Start(cfg Config) (*Profiler, error) {
 		ProfilingTypes:         cfg.ProfileTypes,
 		DisableGCRuns:          cfg.DisableGCRuns,
 		DisableAutomaticResets: cfg.DisableAutomaticResets,
-		SampleRate:             cfg.SampleRate,
 		UploadRate:             cfg.UploadRate,
 	}
 
-	cfg.Logger.Infof("starting profiling session:")
-	cfg.Logger.Infof("  AppName:        %+v", sc.AppName)
-	cfg.Logger.Infof("  Tags:           %+v", sc.Tags)
-	cfg.Logger.Infof("  ProfilingTypes: %+v", sc.ProfilingTypes)
-	cfg.Logger.Infof("  DisableGCRuns:  %+v", sc.DisableGCRuns)
-	cfg.Logger.Infof("  SampleRate:     %+v", sc.SampleRate)
-	cfg.Logger.Infof("  UploadRate:     %+v", sc.UploadRate)
 	s, err := NewSession(sc)
 	if err != nil {
 		return nil, fmt.Errorf("new session: %w", err)

--- a/api.go
+++ b/api.go
@@ -23,11 +23,12 @@ type Config struct {
 	ProfileTypes      []ProfileType
 	DisableGCRuns     bool // this will disable automatic runtime.GC runs between getting the heap profiles
 	HTTPHeaders       map[string]string
-	// Deprecated: the field will be removed in future releases.
-	// DisableAutomaticResets is ignored.
-	DisableAutomaticResets bool
+
 	// Deprecated: the field will be removed in future releases.
 	// Use UploadRate instead.
+	DisableAutomaticResets bool
+	// Deprecated: the field will be removed in future releases.
+	// DisableCumulativeMerge is ignored.
 	DisableCumulativeMerge bool
 	// Deprecated: the field will be removed in future releases.
 	// SampleRate is set to 100 and is not configurable.

--- a/collector.go
+++ b/collector.go
@@ -80,6 +80,7 @@ func newCPUProfileCollector(
 }
 
 func (c *cpuProfileCollector) Start() {
+	c.logger.Debugf("starting cpu profile collector")
 	// From now on, internal pprof.StartCPUProfile
 	// is handled by this collector.
 	internal.SetCollector(c)
@@ -99,7 +100,7 @@ func (c *cpuProfileCollector) Start() {
 			if d := n.Sub(c.timeStarted); d < c.dur {
 				if d < 0 {
 					// Ticker fired after the StartCPUProfile
-					// call, which interrupted background
+					// call, that interrupted background
 					// profiling.
 					d = c.dur
 				}
@@ -168,15 +169,17 @@ func (c *cpuProfileCollector) handleEvent(e event) {
 }
 
 func (c *cpuProfileCollector) Stop() {
+	c.logger.Debugf("stopping cpu profile collector")
 	// Switches back to the standard pprof collector.
 	// If internal pprof.StartCPUProfile is called,
 	// the function blocks until StopCPUProfile.
-	internal.ResetCollector()
+	internal.SetCollector(c.collector)
 	// Note that "halt" is not an event, but rather state
 	// of the collector: the channel can be read multiple
 	// times before the collector stops.
 	close(c.halt)
 	<-c.done
+	c.logger.Debugf("stopping cpu profile collector stopped")
 }
 
 func (c *cpuProfileCollector) StartCPUProfile(w io.Writer) error {
@@ -185,6 +188,7 @@ func (c *cpuProfileCollector) StartCPUProfile(w io.Writer) error {
 }
 
 func (c *cpuProfileCollector) StopCPUProfile() {
+	c.logger.Debugf("cpu profile collector restored")
 	_ = newEvent(stopEvent).send(c.events)
 }
 

--- a/collector.go
+++ b/collector.go
@@ -1,0 +1,216 @@
+package pyroscope
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"runtime/pprof"
+	"time"
+
+	internal "github.com/grafana/pyroscope-go/internal/pprof"
+	"github.com/grafana/pyroscope-go/upstream"
+)
+
+type cpuProfileCollector struct {
+	name        string
+	dur         time.Duration
+	buf         *bytes.Buffer
+	upstream    upstream.Upstream
+	timeStarted time.Time
+
+	// started indicates whether the collector
+	// is interrupted with StartCPUProfile.
+	started bool
+	events  chan event
+
+	halt chan struct{}
+	done chan struct{}
+}
+
+type event struct {
+	typ  eventType
+	done chan error
+	w    io.Writer
+}
+
+type eventType int
+
+const (
+	startEvent eventType = iota
+	stopEvent
+	flushEvent
+)
+
+func newEvent(typ eventType) event {
+	return event{typ: typ, done: make(chan error)}
+}
+
+func (e event) send(c chan<- event) error {
+	c <- e
+	return <-e.done
+}
+
+func newStartEvent(w io.Writer) event {
+	e := newEvent(startEvent)
+	e.w = w
+	return e
+}
+
+func newCPUProfileCollector(
+	name string,
+	upstream upstream.Upstream,
+	period time.Duration,
+) *cpuProfileCollector {
+	buf := bytes.NewBuffer(make([]byte, 0, 1<<10))
+	return &cpuProfileCollector{
+		name:     name,
+		dur:      period,
+		buf:      buf,
+		upstream: upstream,
+		events:   make(chan event),
+		halt:     make(chan struct{}),
+		done:     make(chan struct{}),
+	}
+}
+
+func (c *cpuProfileCollector) Start() {
+	// From now on, internal pprof.StartCPUProfile
+	// is handled by this collector.
+	internal.SetCollector(c)
+	t := time.NewTicker(c.dur)
+
+	// Force pprof.StartCPUProfile: if CPU profiling is already
+	// in progress (pprof.StartCPUProfile called outside the
+	// package), profiling will start once it finishes.
+	_ = c.reset(nil)
+	for {
+		select {
+		case n := <-t.C:
+			// Skip and adjust the timer, if the actual
+			// profile duration is less than the desired,
+			// which may happen if the collector has been
+			// interrupted and then resumed, or flushed.
+			if d := n.Sub(c.timeStarted); d < c.dur {
+				t.Reset(d)
+				continue
+			}
+			t.Reset(c.dur)
+			if !c.started {
+				// Collector can't start collecting profiles
+				// in background while profiling started with
+				// StartCPUProfile (foreground).
+				_ = c.reset(nil)
+			}
+
+		case <-c.halt:
+			t.Stop()
+			if c.started {
+				// Collector can't be stopped in-between
+				// StartCPUProfile and StopCPUProfile calls.
+				continue
+			}
+			pprof.StopCPUProfile()
+			c.upload()
+			close(c.done)
+			return
+
+		case e := <-c.events:
+			c.handleEvent(e)
+		}
+	}
+}
+
+func (c *cpuProfileCollector) handleEvent(e event) {
+	var err error
+	defer func() {
+		e.done <- err
+		close(e.done)
+	}()
+
+	switch e.typ {
+	case startEvent:
+		if c.started { // Misuse.
+			// Just to avoid interruption of the background
+			// profiling that will fail immediately.
+			err = fmt.Errorf("cpu profiling already started")
+		} else {
+			err = c.reset(e.w)
+		}
+		c.started = err == nil
+
+	case stopEvent:
+		if c.started {
+			err = c.reset(nil)
+			c.started = false
+		}
+
+	case flushEvent:
+		if c.started {
+			// Flush can't be done if StartCPUProfile is called,
+			// as we'd need stopping the foreground collector first.
+			err = fmt.Errorf("flush rejected: cpu profiling is in progress")
+		} else {
+			err = c.reset(nil)
+		}
+	}
+}
+
+func (c *cpuProfileCollector) Stop() {
+	// Switches back to the standard pprof collector.
+	// If internal pprof.StartCPUProfile is called,
+	// the function blocks until StopCPUProfile.
+	internal.ResetCollector()
+	// Note that "halt" is not an event, but rather state
+	// of the collector: the channel can be read multiple
+	// times before the collector stops.
+	close(c.halt)
+	<-c.done
+}
+
+func (c *cpuProfileCollector) StartCPUProfile(w io.Writer) error {
+	return newStartEvent(w).send(c.events)
+}
+
+func (c *cpuProfileCollector) StopCPUProfile() {
+	_ = newEvent(stopEvent).send(c.events)
+}
+
+func (c *cpuProfileCollector) Flush() error {
+	return newEvent(flushEvent).send(c.events)
+}
+
+func (c *cpuProfileCollector) reset(w io.Writer) error {
+	pprof.StopCPUProfile()
+	c.upload()
+	var d io.Writer = c.buf
+	if w != nil {
+		// pprof.StopCPUProfile dumps gzipped
+		// profile ignoring any writer failure.
+		d = io.MultiWriter(d, w)
+	}
+	c.timeStarted = time.Now()
+	if err := pprof.StartCPUProfile(d); err != nil {
+		c.timeStarted = time.Time{}
+		c.buf.Reset()
+		return err
+	}
+	return nil
+}
+
+func (c *cpuProfileCollector) upload() {
+	if c.timeStarted.IsZero() {
+		return
+	}
+	c.upstream.Upload(&upstream.UploadJob{
+		Name:            c.name,
+		StartTime:       c.timeStarted,
+		EndTime:         time.Now(),
+		SpyName:         "gospy",
+		SampleRate:      100,
+		Units:           "samples",
+		AggregationType: "sum",
+		Format:          upstream.FormatPprof,
+		Profile:         copyBuf(c.buf.Bytes()),
+	})
+	c.buf.Reset()
+}

--- a/collector_test.go
+++ b/collector_test.go
@@ -1,0 +1,163 @@
+package pyroscope
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/grafana/pyroscope-go/upstream"
+)
+
+func Test_StartCPUProfile_interrupts_background_profiling(t *testing.T) {
+	logger := new(testLogger)
+	collector := new(mockCollector)
+	c := newCPUProfileCollector(
+		"test",
+		new(mockUpstream),
+		logger,
+		100*time.Millisecond,
+	)
+	c.collector = collector
+
+	go c.Start()
+	<-collector.waitStartCPUProfile()
+
+	// Background profile is being collected.
+	// Try to interrupt it with StartCPUProfile.
+	start := collector.waitStartCPUProfile()
+	stop := collector.waitStopCPUProfile()
+	if err := c.StartCPUProfile(io.Discard); err != nil {
+		t.Fatal("failed to start CPU profiling")
+	}
+	<-stop
+	<-start
+
+	// Foreground profile is being collected.
+	// Resume background profiling with StopCPUProfile.
+	start = collector.waitStartCPUProfile()
+	stop = collector.waitStopCPUProfile()
+	c.StopCPUProfile()
+	<-stop
+	<-start
+
+	c.Stop()
+
+	if !reflect.DeepEqual(logger.lines, []string{
+		"starting cpu profile collector",
+		"cpu profile collector interrupted with StartCPUProfile",
+		"cpu profile collector restored",
+		"stopping cpu profile collector",
+		"stopping cpu profile collector stopped",
+	}) {
+		for _, line := range logger.lines {
+			t.Log(line)
+		}
+		t.Fatal("^ unexpected even sequence")
+	}
+}
+
+func Test_StartCPUProfile_blocks_Stop(t *testing.T) {
+	logger := new(testLogger)
+	collector := new(mockCollector)
+	c := newCPUProfileCollector(
+		"test",
+		new(mockUpstream),
+		logger,
+		100*time.Millisecond,
+	)
+	c.collector = collector
+
+	go c.Start()
+	<-collector.waitStartCPUProfile()
+
+	// Background profile is being collected.
+	// Try to interrupt it with StartCPUProfile.
+	start := collector.waitStartCPUProfile()
+	stop := collector.waitStopCPUProfile()
+	if err := c.StartCPUProfile(io.Discard); err != nil {
+		t.Fatal("failed to start CPU profiling")
+	}
+	<-stop
+	<-start
+
+	go c.StopCPUProfile()
+	c.Stop()
+
+	if !reflect.DeepEqual(logger.lines, []string{
+		"starting cpu profile collector",
+		"cpu profile collector interrupted with StartCPUProfile",
+		"stopping cpu profile collector",
+		"cpu profile collector restored",
+		"stopping cpu profile collector stopped",
+	}) {
+		for _, line := range logger.lines {
+			t.Log(line)
+		}
+		t.Fatal("^ unexpected even sequence")
+	}
+}
+
+type mockCollector struct {
+	sync.Mutex
+	start chan struct{}
+	stop  chan struct{}
+}
+
+func (m *mockCollector) waitStartCPUProfile() <-chan struct{} {
+	m.Lock()
+	c := make(chan struct{})
+	m.start = c
+	m.Unlock()
+	return c
+}
+
+func (m *mockCollector) waitStopCPUProfile() <-chan struct{} {
+	m.Lock()
+	c := make(chan struct{})
+	m.stop = c
+	m.Unlock()
+	return c
+}
+
+func (m *mockCollector) StartCPUProfile(_ io.Writer) error {
+	m.Lock()
+	if m.start != nil {
+		close(m.start)
+		m.start = nil
+	}
+	m.Unlock()
+	return nil
+}
+
+func (m *mockCollector) StopCPUProfile() {
+	m.Lock()
+	if m.stop != nil {
+		close(m.stop)
+		m.stop = nil
+	}
+	m.Unlock()
+}
+
+type mockUpstream struct{ uploaded []*upstream.UploadJob }
+
+func (m *mockUpstream) Upload(j *upstream.UploadJob) { m.uploaded = append(m.uploaded, j) }
+
+func (*mockUpstream) Flush() {}
+
+type testLogger struct {
+	sync.Mutex
+	lines []string
+}
+
+func (t *testLogger) Debugf(format string, args ...interface{}) { t.put(format, args...) }
+func (t *testLogger) Infof(format string, args ...interface{})  { t.put(format, args...) }
+func (t *testLogger) Errorf(format string, args ...interface{}) { t.put(format, args...) }
+
+func (t *testLogger) put(format string, args ...interface{}) {
+	t.Lock()
+	t.lines = append(t.lines, fmt.Sprintf(format, args...))
+	t.Unlock()
+}

--- a/example/http.go
+++ b/example/http.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"net/http"
+	_ "net/http/pprof" // register pprof HTTP handlers.
+
+	pyroscope "github.com/grafana/pyroscope-go/http/pprof"
+)
+
+func init() {
+	// Optionally, you can also register Pyroscope handler, that enables
+	// you to seamlessly gather CPU profiles through HTTP while continuously
+	// sending them to Pyroscope.
+	go func() {
+		http.HandleFunc("/debug/pprof/cpu", pyroscope.Profile)
+		_ = http.ListenAndServe(":8080", nil)
+	}()
+}

--- a/http/pprof/README.md
+++ b/http/pprof/README.md
@@ -9,7 +9,7 @@ is already started:
 
 > Could not enable CPU profiling: CPU profiling already in use
 
-The Pyroscope CPU Profiler HTTP handler handles this gracefully by communicating with
+The Pyroscope CPU Profiler HTTP handler serve this gracefully by communicating with
 the Pyroscope profiler, which collects profiles in the background.
 
 ## Usage
@@ -31,3 +31,7 @@ func main() {
 	http.Handle("/debug/pprof/cpu", pprof.Profile())
 }
 ```
+
+With each invocation of the handler, it suspends the Pyroscope profiler, gathers a CPU
+profile, dispatches the collected profile to both the caller and the Pyroscope profiler,
+and subsequently resumes the profiler.

--- a/http/pprof/README.md
+++ b/http/pprof/README.md
@@ -1,0 +1,33 @@
+# Pyroscope CPU Profiler HTTP Handler
+
+This package facilitates the collection of CPU profiles via HTTP without disrupting
+the background operation of the Pyroscope profiler. It enables you to seamlessly gather
+CPU profiles through HTTP while continuously sending them to Pyroscope.
+
+The standard Go pprof HTTP endpoint `/debug/pprof/profile` returns an error if profiling
+is already started:
+
+> Could not enable CPU profiling: CPU profiling already in use
+
+The Pyroscope CPU Profiler HTTP handler handles this gracefully by communicating with
+the Pyroscope profiler, which collects profiles in the background.
+
+## Usage
+
+The package does not register the handler automatically. It is highly recommended to
+avoid using the standard path `/debug/pprof/profile` and the default mux because
+attempting to register the handler on the same path will cause a panic. In many cases,
+the `net/http/pprof` package is imported by dependencies, and therefore there is no
+reliable way to avoid the conflict.
+
+```go
+import (
+    "net/http"
+
+    "github.com/grafana/pyroscope-go/http/pprof"
+)
+
+func main() {
+	http.Handle("/debug/pprof/cpu", pprof.Profile())
+}
+```

--- a/http/pprof/pprof.go
+++ b/http/pprof/pprof.go
@@ -11,6 +11,10 @@ import (
 	"github.com/grafana/pyroscope-go/internal/pprof"
 )
 
+func init() {
+	http.HandleFunc("/debug/pprof/profile", Profile)
+}
+
 // Profile responds with the pprof-formatted cpu profile.
 // Profiling lasts for duration specified in seconds GET parameter, or for 30 seconds if not specified.
 // The package initialization registers it as /debug/pprof/profile.

--- a/http/pprof/pprof.go
+++ b/http/pprof/pprof.go
@@ -54,7 +54,7 @@ func collectCPUProfile(ctx context.Context, w io.Writer) error {
 	if err := internal.StartCPUProfile(w); err != nil {
 		return err
 	}
-	defer internal.StopCPUProfile()
 	<-ctx.Done()
+	internal.StopCPUProfile()
 	return nil
 }

--- a/http/pprof/pprof.go
+++ b/http/pprof/pprof.go
@@ -1,0 +1,60 @@
+package pprof
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/grafana/pyroscope-go/internal/pprof"
+)
+
+// Profile responds with the pprof-formatted cpu profile.
+// Profiling lasts for duration specified in seconds GET parameter, or for 30 seconds if not specified.
+// The package initialization registers it as /debug/pprof/profile.
+func Profile(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	sec, err := strconv.ParseInt(r.FormValue("seconds"), 10, 64)
+	if sec <= 0 || err != nil {
+		sec = 30
+	}
+
+	if durationExceedsWriteTimeout(r, float64(sec)) {
+		serveError(w, http.StatusBadRequest, "profile duration exceeds server's WriteTimeout")
+		return
+	}
+
+	// Set Content Type assuming StartCPUProfile will work,
+	// because if it does it start writing.
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Disposition", `attachment; filename="profile"`)
+	ctx, cancel := context.WithTimeout(r.Context(), time.Duration(sec)*time.Second)
+	defer cancel()
+	if err = collectCPUProfile(ctx, w); err != nil {
+		serveError(w, http.StatusInternalServerError, fmt.Sprintf("Could not enable CPU profiling: %s", err))
+	}
+}
+
+func durationExceedsWriteTimeout(r *http.Request, seconds float64) bool {
+	srv, ok := r.Context().Value(http.ServerContextKey).(*http.Server)
+	return ok && srv.WriteTimeout != 0 && seconds >= srv.WriteTimeout.Seconds()
+}
+
+func serveError(w http.ResponseWriter, status int, txt string) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("X-Go-Pprof", "1")
+	w.Header().Del("Content-Disposition")
+	w.WriteHeader(status)
+	_, _ = fmt.Fprintln(w, txt)
+}
+
+func collectCPUProfile(ctx context.Context, w io.Writer) error {
+	defer pprof.StopCPUProfile()
+	if err := pprof.StartCPUProfile(w); err != nil {
+		return err
+	}
+	<-ctx.Done()
+	return nil
+}

--- a/http/pprof/pprof.go
+++ b/http/pprof/pprof.go
@@ -8,12 +8,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/grafana/pyroscope-go/internal/pprof"
+	internal "github.com/grafana/pyroscope-go/internal/pprof"
 )
-
-func init() {
-	http.HandleFunc("/debug/pprof/profile", Profile)
-}
 
 // Profile responds with the pprof-formatted cpu profile.
 // Profiling lasts for duration specified in seconds GET parameter, or for 30 seconds if not specified.
@@ -55,10 +51,10 @@ func serveError(w http.ResponseWriter, status int, txt string) {
 }
 
 func collectCPUProfile(ctx context.Context, w io.Writer) error {
-	defer pprof.StopCPUProfile()
-	if err := pprof.StartCPUProfile(w); err != nil {
+	if err := internal.StartCPUProfile(w); err != nil {
 		return err
 	}
+	defer internal.StopCPUProfile()
 	<-ctx.Done()
 	return nil
 }

--- a/http/pprof/pprof.go
+++ b/http/pprof/pprof.go
@@ -1,3 +1,7 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package pprof
 
 import (

--- a/internal/pprof/pprof.go
+++ b/internal/pprof/pprof.go
@@ -1,0 +1,69 @@
+package pprof
+
+import (
+	"io"
+	"runtime/pprof"
+	"sync"
+)
+
+var c struct {
+	sync.Mutex
+	ref int64
+	fn  func()
+	Collector
+}
+
+type Collector interface {
+	StartCPUProfile(w io.Writer) error
+	StopCPUProfile()
+}
+
+type defaultCollector struct{}
+
+func (c defaultCollector) StartCPUProfile(w io.Writer) error { return pprof.StartCPUProfile(w) }
+func (c defaultCollector) StopCPUProfile()                   { pprof.StopCPUProfile() }
+
+func StartCPUProfile(w io.Writer) error {
+	c.Lock()
+	defer c.Unlock()
+	if c.Collector == nil {
+		c.Collector = defaultCollector{}
+	}
+	err := c.StartCPUProfile(w)
+	if err == nil {
+		c.ref++
+	}
+	return err
+}
+
+func StopCPUProfile() {
+	c.Lock()
+	defer c.Unlock()
+	c.StopCPUProfile()
+	if c.ref--; c.ref == 0 && c.fn != nil {
+		c.fn()
+		c.fn = nil
+	}
+}
+
+func SetCollector(collector Collector) {
+	c.Lock()
+	if c.ref == 0 {
+		c.Collector = collector
+		c.Unlock()
+		return
+	}
+	ch := make(chan struct{})
+	fn := c.fn
+	c.fn = func() {
+		if fn != nil {
+			fn()
+		}
+		c.Collector = collector
+		close(ch)
+	}
+	c.Unlock()
+	<-ch
+}
+
+func ResetCollector() { SetCollector(nil) }

--- a/internal/pprof/pprof.go
+++ b/internal/pprof/pprof.go
@@ -18,6 +18,8 @@ type Collector interface {
 	StopCPUProfile()
 }
 
+func DefaultCollector() Collector { return defaultCollector{} }
+
 type defaultCollector struct{}
 
 func (c defaultCollector) StartCPUProfile(w io.Writer) error { return pprof.StartCPUProfile(w) }

--- a/internal/pprof/pprof_test.go
+++ b/internal/pprof/pprof_test.go
@@ -1,0 +1,25 @@
+package pprof
+
+import (
+	"io"
+	"runtime"
+	"testing"
+)
+
+func Test_SetCollector(t *testing.T) {
+	for i := 0; i < 20; i++ {
+		_ = StartCPUProfile(io.Discard)
+		// SetCollector blocks until StopCPUProfile is called.
+		done := make(chan struct{})
+		go func() {
+			ResetCollector()
+			close(done)
+		}()
+		runtime.Gosched()
+		StopCPUProfile()
+		<-done
+		if c.Collector != nil {
+			t.Fatal("collector was not reset")
+		}
+	}
+}

--- a/internal/pprof/pprof_test.go
+++ b/internal/pprof/pprof_test.go
@@ -23,3 +23,13 @@ func Test_SetCollector(t *testing.T) {
 		}
 	}
 }
+
+func Test_DefaultCollector(t *testing.T) {
+	if err := StartCPUProfile(io.Discard); err != nil {
+		t.Fatalf("Default collector StartCPUProfile: %v", err)
+	}
+	if err := StartCPUProfile(io.Discard); err == nil {
+		t.Fatalf("Default collector must fail on consecuitive StartCPUProfile")
+	}
+	StopCPUProfile()
+}

--- a/sample_types.go
+++ b/sample_types.go
@@ -1,0 +1,52 @@
+package pyroscope
+
+import (
+	"github.com/grafana/pyroscope-go/upstream"
+)
+
+var (
+	sampleTypeConfigHeap = map[string]*upstream.SampleType{
+		"alloc_objects": {
+			Units:      "objects",
+			Cumulative: false,
+		},
+		"alloc_space": {
+			Units:      "bytes",
+			Cumulative: false,
+		},
+		"inuse_space": {
+			Units:       "bytes",
+			Aggregation: "average",
+			Cumulative:  false,
+		},
+		"inuse_objects": {
+			Units:       "objects",
+			Aggregation: "average",
+			Cumulative:  false,
+		},
+	}
+	sampleTypeConfigMutex = map[string]*upstream.SampleType{
+		"contentions": {
+			DisplayName: "mutex_count",
+			Units:       "lock_samples",
+			Cumulative:  false,
+		},
+		"delay": {
+			DisplayName: "mutex_duration",
+			Units:       "lock_nanoseconds",
+			Cumulative:  false,
+		},
+	}
+	sampleTypeConfigBlock = map[string]*upstream.SampleType{
+		"contentions": {
+			DisplayName: "block_count",
+			Units:       "lock_samples",
+			Cumulative:  false,
+		},
+		"delay": {
+			DisplayName: "block_duration",
+			Units:       "lock_nanoseconds",
+			Cumulative:  false,
+		},
+	}
+)

--- a/session.go
+++ b/session.go
@@ -2,12 +2,7 @@ package pyroscope
 
 import (
 	"bytes"
-	crand "crypto/rand"
-	"encoding/binary"
-	"encoding/hex"
-	"hash/fnv"
-	"math/rand"
-	"os"
+	"math"
 	"runtime"
 	"runtime/debug"
 	"runtime/pprof"
@@ -19,71 +14,22 @@ import (
 	"github.com/grafana/pyroscope-go/upstream"
 )
 
-var (
-	sampleTypeConfigHeap = map[string]*upstream.SampleType{
-		"alloc_objects": {
-			Units:      "objects",
-			Cumulative: false,
-		},
-		"alloc_space": {
-			Units:      "bytes",
-			Cumulative: false,
-		},
-		"inuse_space": {
-			Units:       "bytes",
-			Aggregation: "average",
-			Cumulative:  false,
-		},
-		"inuse_objects": {
-			Units:       "objects",
-			Aggregation: "average",
-			Cumulative:  false,
-		},
-	}
-	sampleTypeConfigMutex = map[string]*upstream.SampleType{
-		"contentions": {
-			DisplayName: "mutex_count",
-			Units:       "lock_samples",
-			Cumulative:  false,
-		},
-		"delay": {
-			DisplayName: "mutex_duration",
-			Units:       "lock_nanoseconds",
-			Cumulative:  false,
-		},
-	}
-	sampleTypeConfigBlock = map[string]*upstream.SampleType{
-		"contentions": {
-			DisplayName: "block_count",
-			Units:       "lock_samples",
-			Cumulative:  false,
-		},
-		"delay": {
-			DisplayName: "block_duration",
-			Units:       "lock_nanoseconds",
-			Cumulative:  false,
-		},
-	}
-)
-
 type Session struct {
 	// configuration, doesn't change
-	upstream               upstream.Upstream
-	sampleRate             uint32
-	profileTypes           []ProfileType
-	uploadRate             time.Duration
-	disableGCRuns          bool
+	upstream      upstream.Upstream
+	profileTypes  []ProfileType
+	uploadRate    time.Duration
+	disableGCRuns bool
+	// Deprecated: the field will be removed in future releases.
 	DisableAutomaticResets bool
 
-	logger    Logger
-	stopOnce  sync.Once
-	stopCh    chan struct{}
-	wg        sync.WaitGroup
-	flushCh   chan *flush
-	trieMutex sync.Mutex
+	logger   Logger
+	stopOnce sync.Once
+	stopCh   chan struct{}
+	wg       sync.WaitGroup
+	flushCh  chan *flush
 
 	// these things do change:
-	cpuBuf *bytes.Buffer
 	memBuf *bytes.Buffer
 
 	goroutinesBuf *bytes.Buffer
@@ -97,20 +43,24 @@ type Session struct {
 	deltaBlock *godeltaprof.BlockProfiler
 	deltaMutex *godeltaprof.BlockProfiler
 	deltaHeap  *godeltaprof.HeapProfiler
+	cpu        *cpuProfileCollector
 }
 
 type SessionConfig struct {
-	Upstream               upstream.Upstream
-	Logger                 Logger
-	AppName                string
-	Tags                   map[string]string
-	ProfilingTypes         []ProfileType
-	DisableGCRuns          bool
+	Upstream       upstream.Upstream
+	Logger         Logger
+	AppName        string
+	Tags           map[string]string
+	ProfilingTypes []ProfileType
+	DisableGCRuns  bool
+	UploadRate     time.Duration
+
+	// Deprecated: the field will be removed in future releases.
 	DisableAutomaticResets bool
-	// Deprecated: the field is ignored and does nothing
+	// Deprecated: the field will be removed in future releases.
 	DisableCumulativeMerge bool
-	SampleRate             uint32
-	UploadRate             time.Duration
+	// Deprecated: the field will be removed in future releases.
+	SampleRate uint32
 }
 
 type flush struct {
@@ -119,32 +69,47 @@ type flush struct {
 }
 
 func NewSession(c SessionConfig) (*Session, error) {
+	if c.UploadRate == 0 {
+		// For backward compatibility.
+		c.UploadRate = 15 * time.Second
+	}
+
+	c.Logger.Infof("starting profiling session:")
+	c.Logger.Infof("  AppName:        %+v", c.AppName)
+	c.Logger.Infof("  Tags:           %+v", c.Tags)
+	c.Logger.Infof("  ProfilingTypes: %+v", c.ProfilingTypes)
+	c.Logger.Infof("  DisableGCRuns:  %+v", c.DisableGCRuns)
+	c.Logger.Infof("  UploadRate:     %+v", c.UploadRate)
+
+	if c.DisableAutomaticResets {
+		c.UploadRate = math.MaxInt64
+	}
+
 	appName, err := mergeTagsWithAppName(c.AppName, newSessionID(), c.Tags)
 	if err != nil {
 		return nil, err
 	}
 
 	ps := &Session{
-		upstream:               c.Upstream,
-		appName:                appName,
-		profileTypes:           c.ProfilingTypes,
-		disableGCRuns:          c.DisableGCRuns,
-		DisableAutomaticResets: c.DisableAutomaticResets,
-		sampleRate:             c.SampleRate,
-		uploadRate:             c.UploadRate,
-		stopCh:                 make(chan struct{}),
-		flushCh:                make(chan *flush),
-		logger:                 c.Logger,
-		cpuBuf:                 &bytes.Buffer{},
-		memBuf:                 &bytes.Buffer{},
-		goroutinesBuf:          &bytes.Buffer{},
-		mutexBuf:               &bytes.Buffer{},
-		blockBuf:               &bytes.Buffer{},
+		upstream:      c.Upstream,
+		appName:       appName,
+		profileTypes:  c.ProfilingTypes,
+		disableGCRuns: c.DisableGCRuns,
+		uploadRate:    c.UploadRate,
+		stopCh:        make(chan struct{}),
+		flushCh:       make(chan *flush),
+		logger:        c.Logger,
+		memBuf:        &bytes.Buffer{},
+		goroutinesBuf: &bytes.Buffer{},
+		mutexBuf:      &bytes.Buffer{},
+		blockBuf:      &bytes.Buffer{},
 
 		deltaBlock: godeltaprof.NewBlockProfiler(),
 		deltaMutex: godeltaprof.NewMutexProfiler(),
 		deltaHeap:  godeltaprof.NewHeapProfiler(),
+		cpu:        newCPUProfileCollector(appName, c.Upstream, c.UploadRate),
 	}
+
 	return ps, nil
 }
 
@@ -178,25 +143,23 @@ func mergeTagsWithAppName(appName string, sid sessionID, tags map[string]string)
 
 // revive:disable-next-line:cognitive-complexity complexity is fine
 func (ps *Session) takeSnapshots() {
-	var automaticResetTicker <-chan time.Time
-	if ps.DisableAutomaticResets {
-		automaticResetTicker = make(chan time.Time)
-	} else {
-		t := time.NewTicker(ps.uploadRate)
-		automaticResetTicker = t.C
-		defer t.Stop()
-	}
+	t := time.NewTicker(ps.uploadRate)
+	defer t.Stop()
 	for {
 		select {
-		case endTime := <-automaticResetTicker:
+		case endTime := <-t.C:
 			ps.reset(ps.startTime, endTime)
+
 		case f := <-ps.flushCh:
 			ps.reset(ps.startTime, ps.truncatedTime())
+			_ = ps.cpu.Flush()
 			ps.upstream.Flush()
 			f.wg.Done()
-			break
+
 		case <-ps.stopCh:
-			return
+			if ps.isCPUEnabled() {
+				ps.cpu.Stop()
+			}
 		}
 	}
 }
@@ -216,6 +179,15 @@ func (ps *Session) Start() error {
 		defer ps.wg.Done()
 		ps.takeSnapshots()
 	}()
+
+	if ps.isCPUEnabled() {
+		ps.wg.Add(1)
+		go func() {
+			defer ps.wg.Done()
+			ps.cpu.Start()
+		}()
+	}
+
 	return nil
 }
 
@@ -266,39 +238,14 @@ func (ps *Session) isGoroutinesEnabled() bool {
 
 func (ps *Session) reset(startTime, endTime time.Time) {
 	ps.logger.Debugf("profiling session reset %s", startTime.String())
-
 	// first reset should not result in an upload
 	if !ps.startTime.IsZero() {
 		ps.uploadData(startTime, endTime)
-	} else {
-		if ps.isCPUEnabled() {
-			pprof.StartCPUProfile(ps.cpuBuf)
-		}
 	}
-
 	ps.startTime = endTime
 }
 
 func (ps *Session) uploadData(startTime, endTime time.Time) {
-	if ps.isCPUEnabled() {
-		pprof.StopCPUProfile()
-		defer func() {
-			pprof.StartCPUProfile(ps.cpuBuf)
-		}()
-		ps.upstream.Upload(&upstream.UploadJob{
-			Name:            ps.appName,
-			StartTime:       startTime,
-			EndTime:         endTime,
-			SpyName:         "gospy",
-			SampleRate:      100,
-			Units:           "samples",
-			AggregationType: "sum",
-			Format:          upstream.FormatPprof,
-			Profile:         copyBuf(ps.cpuBuf.Bytes()),
-		})
-		ps.cpuBuf.Reset()
-	}
-
 	if ps.isGoroutinesEnabled() {
 		p := pprof.Lookup("goroutine")
 		if p != nil {
@@ -415,37 +362,10 @@ func (ps *Session) dumpBlockProfile(startTime time.Time, endTime time.Time) {
 }
 
 func (ps *Session) Stop() {
-	ps.trieMutex.Lock()
-	defer ps.trieMutex.Unlock()
-
 	ps.stopOnce.Do(func() {
-		// TODO: wait for stopCh consumer to finish!
 		close(ps.stopCh)
 		ps.wg.Wait()
-		// before stopping, upload the tries
-		ps.uploadLastBitOfData(time.Now())
 	})
-}
-
-func (ps *Session) uploadLastBitOfData(now time.Time) {
-	if ps.isCPUEnabled() {
-		pprof.StopCPUProfile()
-		prof := ps.cpuBuf.Bytes()
-		if len(prof) == 0 {
-			return
-		}
-		ps.upstream.Upload(&upstream.UploadJob{
-			Name:            ps.appName,
-			StartTime:       ps.startTime,
-			EndTime:         now,
-			SpyName:         "gospy",
-			SampleRate:      100,
-			Units:           "samples",
-			AggregationType: "sum",
-			Format:          upstream.FormatPprof,
-			Profile:         copyBuf(prof),
-		})
-	}
 }
 
 func (ps *Session) flush(wait bool) {
@@ -468,57 +388,4 @@ func numGC() uint32 {
 	var memStats runtime.MemStats
 	runtime.ReadMemStats(&memStats)
 	return memStats.NumGC
-}
-
-const sessionIDLabelName = "__session_id__"
-
-type sessionID uint64
-
-func (s sessionID) String() string {
-	var b [8]byte
-	binary.LittleEndian.PutUint64(b[:], uint64(s))
-	return hex.EncodeToString(b[:])
-}
-
-func newSessionID() sessionID { return globalSessionIDGenerator.newSessionID() }
-
-var globalSessionIDGenerator = newSessionIDGenerator()
-
-type sessionIDGenerator struct {
-	sync.Mutex
-	src *rand.Rand
-}
-
-func (gen *sessionIDGenerator) newSessionID() sessionID {
-	var b [8]byte
-	gen.Lock()
-	_, _ = gen.src.Read(b[:])
-	gen.Unlock()
-	return sessionID(binary.LittleEndian.Uint64(b[:]))
-}
-
-func newSessionIDGenerator() *sessionIDGenerator {
-	s, ok := sessionIDHostSeed()
-	if !ok {
-		s = sessionIDRandSeed()
-	}
-	return &sessionIDGenerator{src: rand.New(rand.NewSource(s))}
-}
-
-func sessionIDRandSeed() int64 {
-	var rndSeed int64
-	_ = binary.Read(crand.Reader, binary.LittleEndian, &rndSeed)
-	return rndSeed
-}
-
-var hostname = os.Hostname
-
-func sessionIDHostSeed() (int64, bool) {
-	v, err := hostname()
-	if err != nil {
-		return 0, false
-	}
-	h := fnv.New64a()
-	_, _ = h.Write([]byte(v))
-	return int64(h.Sum64()), true
 }

--- a/session.go
+++ b/session.go
@@ -110,7 +110,7 @@ func NewSession(c SessionConfig) (*Session, error) {
 		deltaBlock: godeltaprof.NewBlockProfiler(),
 		deltaMutex: godeltaprof.NewMutexProfiler(),
 		deltaHeap:  godeltaprof.NewHeapProfiler(),
-		cpu:        newCPUProfileCollector(appName, c.Upstream, c.UploadRate),
+		cpu:        newCPUProfileCollector(appName, c.Upstream, c.Logger, c.UploadRate),
 	}
 
 	return ps, nil

--- a/session.go
+++ b/session.go
@@ -56,10 +56,13 @@ type SessionConfig struct {
 	UploadRate     time.Duration
 
 	// Deprecated: the field will be removed in future releases.
+	// Use UploadRate instead.
 	DisableAutomaticResets bool
 	// Deprecated: the field will be removed in future releases.
+	// DisableCumulativeMerge is ignored.
 	DisableCumulativeMerge bool
 	// Deprecated: the field will be removed in future releases.
+	// SampleRate is set to 100 and is not configurable.
 	SampleRate uint32
 }
 

--- a/session_id.go
+++ b/session_id.go
@@ -1,0 +1,64 @@
+package pyroscope
+
+import (
+	crand "crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+	"hash/fnv"
+	"math/rand"
+	"os"
+	"sync"
+)
+
+const sessionIDLabelName = "__session_id__"
+
+type sessionID uint64
+
+func (s sessionID) String() string {
+	var b [8]byte
+	binary.LittleEndian.PutUint64(b[:], uint64(s))
+	return hex.EncodeToString(b[:])
+}
+
+func newSessionID() sessionID { return globalSessionIDGenerator.newSessionID() }
+
+var globalSessionIDGenerator = newSessionIDGenerator()
+
+type sessionIDGenerator struct {
+	sync.Mutex
+	src *rand.Rand
+}
+
+func (gen *sessionIDGenerator) newSessionID() sessionID {
+	var b [8]byte
+	gen.Lock()
+	_, _ = gen.src.Read(b[:])
+	gen.Unlock()
+	return sessionID(binary.LittleEndian.Uint64(b[:]))
+}
+
+func newSessionIDGenerator() *sessionIDGenerator {
+	s, ok := sessionIDHostSeed()
+	if !ok {
+		s = sessionIDRandSeed()
+	}
+	return &sessionIDGenerator{src: rand.New(rand.NewSource(s))}
+}
+
+func sessionIDRandSeed() int64 {
+	var rndSeed int64
+	_ = binary.Read(crand.Reader, binary.LittleEndian, &rndSeed)
+	return rndSeed
+}
+
+var hostname = os.Hostname
+
+func sessionIDHostSeed() (int64, bool) {
+	v, err := hostname()
+	if err != nil {
+		return 0, false
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(v))
+	return int64(h.Sum64()), true
+}


### PR DESCRIPTION
### Pyroscope CPU Profiler HTTP Handler

This package facilitates the collection of CPU profiles via HTTP without disrupting the background operation of the Pyroscope profiler. It enables you to seamlessly gather CPU profiles through HTTP while continuously sending them to Pyroscope.

The standard Go pprof HTTP endpoint `/debug/pprof/profile` returns an error if profiling is already started:

> Could not enable CPU profiling: CPU profiling already in use

The Pyroscope CPU Profiler HTTP handler handles this gracefully by communicating with the Pyroscope profiler, which collects profiles in the background.

### Usage

The package does not register the handler automatically. It is highly recommended to avoid using the standard path `/debug/pprof/profile` and the default mux because attempting to register the handler on the same path will cause a panic. In many cases, the `net/http/pprof` package is imported by dependencies, and therefore there is no reliable way to avoid the conflict.

```go
import (
    "net/http"

    "github.com/grafana/pyroscope-go/http/pprof"
)

func main() {
	http.Handle("/debug/pprof/cpu", pprof.Profile())
}
```
