### PR TITLE
fix(godeltaprof): remove go build upper bound tag for runtime_expandFinalInlineFrame runtime_cyclesPerSecond

### DIFF
--- a/godeltaprof/internal/pprof/stub.go
+++ b/godeltaprof/internal/pprof/stub.go
@@ -1,6 +1,3 @@
-//go:build go1.16 && !go1.23
-// +build go1.16,!go1.23
-
 package pprof
 
 // unsafe is required for go:linkname


### PR DESCRIPTION
We run tests on gotip, so I think we dont need this build tag at all

This fixes build on gotip

 https://github.com/grafana/pyroscope-go/issues/94