### PR TITLE
chore: fix CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TEST_PACKAGES := ./... ./godeltaprof/compat/... ./godeltaprof/...
 
 .PHONY: test
 test:
-	go test -race $(shell go list $(TEST_PACKAGES))
+	go test -race $(shell go list $(TEST_PACKAGES) | grep -v /example)
 
 .PHONY: go/mod
 go/mod:

--- a/example/timing.go
+++ b/example/timing.go
@@ -6,7 +6,7 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/pyroscope-io/client/pyroscope"
+	"github.com/grafana/pyroscope-go"
 )
 
 //go:noinline


### PR DESCRIPTION
* Excludes `example` package from tests: `main` is declared twice, which is fine, but breaks CI – maybe we should put examples into a submodule
* Replaces `github.com/pyroscope-io/client/pyroscope` with `github.com/grafana/pyroscope-go`