### PR TITLE
fix(session): fix panic: close of closed channel

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -1,0 +1,15 @@
+package pyroscope
+
+import (
+	"testing"
+)
+
+func TestProfilerStartStop(t *testing.T) {
+	profiler, err := Start(Config{
+		ApplicationName: "test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	profiler.Stop()
+}

--- a/session.go
+++ b/session.go
@@ -163,6 +163,7 @@ func (ps *Session) takeSnapshots() {
 			if ps.isCPUEnabled() {
 				ps.cpu.Stop()
 			}
+			return
 		}
 	}
 }


### PR DESCRIPTION
This new version breaks our internal service, the panic stack:

```
panic: close of closed channel

goroutine 41 [running]:
github.com/grafana/pyroscope-go.(*cpuProfileCollector).Stop(0x1400018e090)
	/tmp/pyroscope-go/collector.go:181 +0xa0
github.com/grafana/pyroscope-go.(*Session).takeSnapshots(0x14000192000)
	/tmp/pyroscope-go/session.go:164 +0x21c
github.com/grafana/pyroscope-go.(*Session).Start.func1()
	/tmp/pyroscope-go/session.go:183 +0x54
created by github.com/grafana/pyroscope-go.(*Session).Start in goroutine 35
	/tmp/pyroscope-go/session.go:181 +0x98
exit status 2
FAIL	github.com/grafana/pyroscope-go	0.221s
```

@korniltsev 