### PR TITLE
fix(godeltaprof): incorrect function names for generics functions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.16', '1.17', '1.18', '1.19', '1.20', '1.21', 'tip']
+        go: ['1.16', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', 'tip']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/godeltaprof/internal/pprof/proto.go
+++ b/godeltaprof/internal/pprof/proto.go
@@ -524,13 +524,14 @@ func (b *profileBuilder) emitLocation() uint64 {
 	b.pb.uint64Opt(tagLocation_Address, uint64(firstFrame.PC))
 	for _, frame := range b.deck.frames {
 		// Write out each line in frame expansion.
-		funcID := uint64(b.funcs[frame.Function])
+		funcName := runtime_FrameSymbolName(&frame)
+		funcID := uint64(b.funcs[funcName])
 		if funcID == 0 {
 			funcID = uint64(len(b.funcs)) + 1
-			b.funcs[frame.Function] = int(funcID)
+			b.funcs[funcName] = int(funcID)
 			var name string
 			if b.opt.GenericsFrames {
-				name = runtime_FrameSymbolName(&frame)
+				name = funcName
 			} else {
 				name = frame.Function
 			}

--- a/godeltaprof/internal/pprof/proto.go
+++ b/godeltaprof/internal/pprof/proto.go
@@ -474,7 +474,7 @@ func (d *pcDeck) tryAdd(pc uintptr, frames []runtime.Frame, symbolizeResult symb
 		if last.Entry != newFrame.Entry { // newFrame is for a different function.
 			return false
 		}
-		if last.Function == newFrame.Function { // maybe recursion.
+		if runtime_FrameSymbolName(&last) == runtime_FrameSymbolName(&newFrame) { // maybe recursion.
 			return false
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/grafana/pyroscope-go/issues/82

This PR ports fixes from upstream for the following issues https://github.com/golang/go/issues/64528 and https://github.com/golang/go/issues/64641

Specifically https://github.com/golang/go/commit/20a03fc7130d8d99b513071c7e413b436ea649a2 and https://github.com/golang/go/commit/d95e25e83c922aa63fcb1f596d6bdf1786789edb