### PR TITLE
fix: avoid panic in init godeltaprof/http/pprof for go 1.23

### DIFF
--- a/godeltaprof/http/pprof/pprof.go
+++ b/godeltaprof/http/pprof/pprof.go
@@ -21,9 +21,10 @@ type deltaProfiler interface {
 }
 
 func init() {
-	http.HandleFunc("/debug/pprof/delta_heap", Heap)
-	http.HandleFunc("/debug/pprof/delta_block", Block)
-	http.HandleFunc("/debug/pprof/delta_mutex", Mutex)
+	prefix := routePrefix()
+	http.HandleFunc(prefix+"/debug/pprof/delta_heap", Heap)
+	http.HandleFunc(prefix+"/debug/pprof/delta_block", Block)
+	http.HandleFunc(prefix+"/debug/pprof/delta_mutex", Mutex)
 }
 
 func Heap(w http.ResponseWriter, r *http.Request) {

--- a/godeltaprof/http/pprof/pprof_go21.go
+++ b/godeltaprof/http/pprof/pprof_go21.go
@@ -1,0 +1,7 @@
+//go:build !go1.22
+
+package pprof
+
+func routePrefix() string {
+	return ""
+}

--- a/godeltaprof/http/pprof/pprof_go22.go
+++ b/godeltaprof/http/pprof/pprof_go22.go
@@ -1,0 +1,18 @@
+//go:build go1.22
+
+package pprof
+
+import "os"
+
+func routePrefix() string {
+	// As of go 1.23
+	// https://github.com/golang/go/blob/9fcffc53593c5cd103630d0d24ef8bd91e17246d/src/net/http/pprof/pprof.go#L98-L97
+	// https://github.com/golang/go/commit/9fcffc53593c5cd103630d0d24ef8bd91e17246d
+	prefix := ""
+	//if godebug.New("httpmuxgo121").Value() != "1" { // todo, how to check it?
+	if os.Getenv("PYROSCOPE_GODELTAPROF_HTTPMUXGO121") != "1" {
+		prefix = "GET "
+	}
+	return prefix
+
+}

--- a/godeltaprof/http/pprof/pprof_go22.go
+++ b/godeltaprof/http/pprof/pprof_go22.go
@@ -2,17 +2,9 @@
 
 package pprof
 
-import "os"
-
 func routePrefix() string {
-	// As of go 1.23
+	// As of go 1.23 we will panic if we don't prefix with "GET "
 	// https://github.com/golang/go/blob/9fcffc53593c5cd103630d0d24ef8bd91e17246d/src/net/http/pprof/pprof.go#L98-L97
 	// https://github.com/golang/go/commit/9fcffc53593c5cd103630d0d24ef8bd91e17246d
-	prefix := ""
-	//if godebug.New("httpmuxgo121").Value() != "1" { // todo, how to check it?
-	if os.Getenv("PYROSCOPE_GODELTAPROF_HTTPMUXGO121") != "1" {
-		prefix = "GET "
-	}
-	return prefix
-
+	return "GET "
 }


### PR DESCRIPTION
fix https://github.com/grafana/pyroscope-go/issues/118

go 1.23 changed the way `net/http/pprof` registers pprof endpoints by prefixing with `"GET "`

This leads to panics if godeltaprof does not do the same.

https://github.com/golang/go/blob/9fcffc53593c5cd103630d0d24ef8bd91e17246d/src/net/http/pprof/pprof.go#L98-L97

https://github.com/golang/go/commit/9fcffc53593c5cd103630d0d24ef8bd91e17246d