### PR TITLE
feat: expose http.Client override through the main configuration

### DIFF
--- a/api.go
+++ b/api.go
@@ -22,6 +22,7 @@ type Config struct {
 	ProfileTypes      []ProfileType
 	DisableGCRuns     bool // this will disable automatic runtime.GC runs between getting the heap profiles
 	HTTPHeaders       map[string]string
+	HTTPClient        remote.HTTPClient
 
 	// Deprecated: the field will be removed in future releases.
 	// Use BasicAuthUser and BasicAuthPassword instead.
@@ -63,6 +64,7 @@ func Start(cfg Config) (*Profiler, error) {
 		BasicAuthUser:     cfg.BasicAuthUser,
 		BasicAuthPassword: cfg.BasicAuthPassword,
 		HTTPHeaders:       cfg.HTTPHeaders,
+		HTTPClient:        cfg.HTTPClient,
 		Address:           cfg.ServerAddress,
 		Threads:           5, // per each profile type upload
 		Timeout:           30 * time.Second,


### PR DESCRIPTION
An override to the remote `http.Client` has been added to the remote configuration with PR #101 , but using it seems to require reimplementing the `Start` function from the `api` package (unless I'm missing something). This PR adds an `HTTPClient` field to the main configuration struct to facilitate customization.

I guess there could be many different reasons to justify this, mine is to allow overriding the CA certificate store without rebuilding the system CA store, which can be difficult or even impossible in specific contexts.