### PR TITLE
fix:  TestGenericsHashKeyInPprofBuilder, TestGenericsShape on gotip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
-GO_VERSION_PRE20 := $(shell go version | awk '{print $$3}' | awk -F '.' '{print ($$1 == "go1" && int($$2) < 20)}')
 TEST_PACKAGES := ./... ./godeltaprof/compat/... ./godeltaprof/...
+GO ?= go
+GOTIP ?= gotip
 
 .PHONY: test
 test:
-	go test -race $(shell go list $(TEST_PACKAGES) | grep -v /example)
+	$(GO) test -race $(shell $(GO) list $(TEST_PACKAGES) | grep -v /example)
 
 .PHONY: go/mod
 go/mod:
@@ -18,6 +19,6 @@ go/mod:
 # https://github.com/grafana/pyroscope-go/issues/129
 .PHONY: gotip/fix
 gotip/fix:
-	cd godeltaprof/compat/ && gotip get -d -v golang.org/x/tools@v0.25.0
+	cd godeltaprof/compat/ && $(GOTIP) get -v golang.org/x/tools@v0.34.0
 	git --no-pager diff
 	! git diff | grep toolchain


### PR DESCRIPTION
1. fix `TestGenericsShape`  
Starting with https://go-review.googlesource.com/c/go/+/649035 compiler may stack allocate small allocations with constant sizes which breaks the allocation test.

~This PR moves the allocation size to a global variable to trick the compiler and not eliminate the allocation.~
This PR makes the allocation escape to heap so that stack allocation is not possible.

2. fix `TestGenericsHashKeyInPprofBuilder` 
Starting with https://go-review.googlesource.com/c/go/+/653856 

This PR makes the allocation escape to heap so that stack allocation is not possible. 