### PR TITLE
fix(remote): race during flush

### DIFF
--- a/upstream/remote/remote.go
+++ b/upstream/remote/remote.go
@@ -43,7 +43,7 @@ type Remote struct {
 	flushWG *sync.WaitGroup
 	started bool
 
-	droppedJobs atomic.Uint64
+	droppedJobs uint64
 }
 
 type HTTPClient interface {
@@ -146,7 +146,7 @@ func (r *Remote) drainJobs() {
 		case x := <-r.jobs:
 			x.flush.Done()
 			r.logger.Errorf("stopped, dropping a profile job")
-			r.droppedJobs.Add(1)
+			atomic.AddUint64(&r.droppedJobs, 1)
 		default:
 			return
 		}
@@ -169,7 +169,7 @@ func (r *Remote) Upload(j *upstream.UploadJob) {
 	default:
 		ij.flush.Done()
 		r.logger.Errorf("remote upload queue is full, dropping a profile job")
-		r.droppedJobs.Add(1)
+		atomic.AddUint64(&r.droppedJobs, 1)
 	}
 }
 

--- a/upstream/remote/remote_test.go
+++ b/upstream/remote/remote_test.go
@@ -103,13 +103,14 @@ func (m *MockHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	args := m.Called(req)
 	err := args.Error(1)
 	a0 := args.Get(0)
-	if resp, ok := a0.(*http.Response); ok {
-		return resp, err
+	switch typed := a0.(type) {
+	case *http.Response:
+		return typed, err
+	case func() *http.Response:
+		return typed(), err
+	default:
+		return nil, fmt.Errorf("unknown mock arg type arg %+v %w", a0, err)
 	}
-	if resp, ok := a0.(func() *http.Response); ok {
-		return resp(), err
-	}
-	return nil, fmt.Errorf("unknown arg %+v %w", a0, err)
 }
 
 func TestConcurrentUploadFlushRace(t *testing.T) {

--- a/upstream/remote/remote_test.go
+++ b/upstream/remote/remote_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -204,7 +205,7 @@ func TestDrainJobs(t *testing.T) {
 	r.Stop()
 	assert.Len(t, r.jobs, 0)
 	r.Flush()
-	require.EqualValues(t, 2, r.droppedJobs.Load())
+	require.EqualValues(t, 2, atomic.LoadUint64(&r.droppedJobs))
 }
 
 func TestStartStopMultipleTimes(t *testing.T) {

--- a/upstream/remote/remote_test.go
+++ b/upstream/remote/remote_test.go
@@ -2,8 +2,11 @@ package remote
 
 import (
 	"bytes"
+	"fmt"
+	"github.com/stretchr/testify/require"
 	"io"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -98,5 +101,139 @@ type MockHTTPClient struct {
 
 func (m *MockHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	args := m.Called(req)
-	return args.Get(0).(*http.Response), args.Error(1)
+	err := args.Error(1)
+	a0 := args.Get(0)
+	if resp, ok := a0.(*http.Response); ok {
+		return resp, err
+	}
+	if resp, ok := a0.(func() *http.Response); ok {
+		return resp(), err
+	}
+	return nil, fmt.Errorf("unknown arg %+v %w", a0, err)
+}
+
+func TestConcurrentUploadFlushRace(t *testing.T) {
+	mockClient := new(MockHTTPClient)
+	mockClient.On("Do", mock.Anything).Return(func() *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewBufferString("OK")),
+		}
+	}, nil)
+	r, err := NewRemote(Config{
+		Threads:    2,
+		Logger:     testutil.NewTestLogger(),
+		HTTPClient: mockClient,
+	})
+	require.NoError(t, err)
+	r.Start()
+	defer r.Stop()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	loop := func(f func()) {
+		timeout := time.After(10 * time.Millisecond)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-timeout:
+					return
+				default:
+					f()
+				}
+			}
+		}()
+	}
+	loop(func() {
+		r.Upload(newJob("job1"))
+	})
+	loop(func() {
+		r.Flush()
+	})
+	wg.Wait()
+}
+
+func TestStartTwice(t *testing.T) {
+	r, err := NewRemote(Config{
+		Threads:    2,
+		Logger:     testutil.NewTestLogger(),
+		HTTPClient: new(MockHTTPClient),
+	})
+	require.NoError(t, err)
+	r.Start()
+	r.Start()
+	r.Stop()
+}
+
+func TestUploadNotStarted(t *testing.T) {
+	c := new(MockHTTPClient)
+	r, err := NewRemote(Config{
+		Threads:    2,
+		Logger:     testutil.NewTestLogger(),
+		HTTPClient: c,
+	})
+	require.NoError(t, err)
+	r.Upload(newJob("j1"))
+	require.Len(t, r.jobs, 0)
+	c.AssertExpectations(t)
+}
+
+func TestDrainJobs(t *testing.T) {
+	const requestDuration = 100 * time.Millisecond
+	c := new(MockHTTPClient)
+	c.On("Do", mock.Anything).Return(func() *http.Response {
+		time.Sleep(requestDuration)
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewBufferString("OK")),
+		}
+	}, nil).Once()
+	logger := testutil.NewTestLogger()
+	r, err := NewRemote(Config{
+		Threads:    1,
+		Logger:     logger,
+		HTTPClient: c,
+	})
+	require.NoError(t, err)
+	r.Start()
+	r.Upload(newJob("job1"))
+	r.Upload(newJob("job2"))
+	r.Upload(newJob("job3"))
+	time.Sleep(time.Millisecond)
+	r.Stop()
+	assert.Len(t, r.jobs, 0)
+	r.Flush()
+	require.EqualValues(t, 2, r.droppedJobs.Load())
+}
+
+func TestStartStopMultipleTimes(t *testing.T) {
+	c := new(MockHTTPClient)
+
+	c.On("Do", mock.Anything).Return(func() *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewBufferString("OK")),
+		}
+	}, nil).Once()
+	logger := testutil.NewTestLogger()
+	r, err := NewRemote(Config{
+		Threads:    1,
+		Logger:     logger,
+		HTTPClient: c,
+	})
+	require.NoError(t, err)
+	r.Start()
+	r.Stop()
+	r.Start()
+	defer r.Stop()
+	r.Upload(newJob("j1"))
+	time.Sleep(time.Millisecond)
+	c.AssertExpectations(t)
+}
+
+func newJob(name string) *upstream.UploadJob {
+	return &upstream.UploadJob{
+		Name: name,
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/grafana/pyroscope-go/issues/153
Fixes data race during Flush
~Makes `Start` not start twice if already started.~
~Makes `Stop` do nothing if not started.~
~Makes `Start` / `Stop` reusable - allows to start-stop-start-stop~
~Makes `Upload` drop the upload job if not started~