### PR TITLE
chore: remove golang.org/x/tools dependency from compat tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -71,11 +71,6 @@ jobs:
           echo "GOPATH=$HOME/go" >> "$GITHUB_ENV"
           echo "$HOME/go/bin" >> "$GITHUB_PATH"
           echo "$HOME/sdk/gotip/bin" >> "$GITHUB_PATH"
-          make go/1_27_outdated_tools
-
-      - name: Fix outdated go tools for go1.24+
-        if: contains('1.24 1.25 1.26', matrix.go)
-        run: make go/1_24_outdated_tools
 
       - name: Build example application
         run: make examples

--- a/.github/workflows/gotip_cron_test.yml
+++ b/.github/workflows/gotip_cron_test.yml
@@ -29,7 +29,6 @@ jobs:
           echo "GOPATH=$HOME/go" >> "$GITHUB_ENV"
           echo "$HOME/go/bin" >> "$GITHUB_PATH"
           echo "$HOME/sdk/gotip/bin" >> "$GITHUB_PATH"
-          make gotip/fix
       - name: Build example application
         run: make examples
       - name: Run tests

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 TEST_PACKAGES := ./... ./godeltaprof/compat/... ./godeltaprof/...
 GO ?= go
-GOTIP ?= gotip
 
 GOLANGCI_LINT_VERSION ?= v2.2.2
 TOOLS_DIR := $(CURDIR)/.tools
@@ -19,19 +18,6 @@ go/mod:
 	cd godeltaprof/compat/ && GO111MODULE=on go mod tidy
 	cd godeltaprof/ && GO111MODULE=on go mod download
 	cd godeltaprof/ && GO111MODULE=on go mod tidy
-
-# Update tools for go versions after 1.24
-# https://github.com/grafana/pyroscope-go/issues/129
-.PHONY: go/1_24_outdated_tools
-go/1_24_outdated_tools:
-	cd godeltaprof/compat/ && $(GO) get -v golang.org/x/tools@v0.34.0
-	git --no-pager diff
-
-# Update tools for go versions after 1.27
-.PHONY: go/1_27_outdated_tools
-go/1_27_outdated_tools:
-	cd godeltaprof/compat/ && $(GO) get -v golang.org/x/tools@v0.43.1-0.20260325161218-aa5e55c6180a
-	git --no-pager diff
 
 .PHONY: install-lint
 install-lint:

--- a/godeltaprof/compat/go.mod
+++ b/godeltaprof/compat/go.mod
@@ -7,15 +7,12 @@ require (
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.5
 	github.com/klauspost/compress v1.17.8
 	github.com/stretchr/testify v1.11.1
-	golang.org/x/tools v0.16.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/mod v0.17.0 // indirect
-	golang.org/x/sync v0.8.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/godeltaprof/compat/go.sum
+++ b/godeltaprof/compat/go.sum
@@ -21,12 +21,6 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
-golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
-golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
-golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
-golang.org/x/tools v0.16.0 h1:GO788SKMRunPIBCXiQyo2AaexLstOrVhuAL5YwsckQM=
-golang.org/x/tools v0.16.0/go.mod h1:kYVVN6I1mBNoB1OX+noeBjbRk4IUEPa7JJ+TJMEooJ0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/godeltaprof/compat/stub_test.go
+++ b/godeltaprof/compat/stub_test.go
@@ -22,6 +22,7 @@ import (
 
 var errNoExportFile = errors.New("no export file")
 
+//nolint:gochecknoglobals // cache shared across test helpers
 var exportFileCache = make(map[string]string)
 
 func goListExport(pkg string) (string, error) {

--- a/godeltaprof/compat/stub_test.go
+++ b/godeltaprof/compat/stub_test.go
@@ -2,6 +2,7 @@ package compat
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/importer"
@@ -13,18 +14,21 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-var exportFileCache sync.Map
+//nolint:gochecknoglobals
+var errNoExportFile = errors.New("no export file")
+
+//nolint:gochecknoglobals
+var exportFileCache = make(map[string]string)
 
 func goListExport(pkg string) (string, error) {
-	if v, ok := exportFileCache.Load(pkg); ok {
-		return v.(string), nil
+	if v, ok := exportFileCache[pkg]; ok {
+		return v, nil
 	}
 	out, err := exec.Command("go", "list", "-export", "-f", "{{.Export}}", pkg).Output()
 	if err != nil {
@@ -32,10 +36,16 @@ func goListExport(pkg string) (string, error) {
 	}
 	path := strings.TrimSpace(string(out))
 	if path == "" {
-		return "", fmt.Errorf("no export file for %s", pkg)
+		return "", fmt.Errorf("%s: %w", pkg, errNoExportFile)
 	}
-	exportFileCache.Store(pkg, path)
+	exportFileCache[pkg] = path
+
 	return path, nil
+}
+
+type goListJSON struct {
+	Dir     string   `json:"Dir"`
+	GoFiles []string `json:"GoFiles"`
 }
 
 func checkSignature(t *testing.T, pkg string, name string, expectedSignature string) {
@@ -47,14 +57,11 @@ func checkSignature(t *testing.T, pkg string, name string, expectedSignature str
 	out, err := exec.Command("go", "list", "-json", pkg).Output()
 	require.NoError(t, err, "go list -json failed for %s", pkg)
 
-	var pkgInfo struct {
-		Dir     string
-		GoFiles []string
-	}
+	var pkgInfo goListJSON
 	require.NoError(t, json.Unmarshal(out, &pkgInfo))
 
 	fset := token.NewFileSet()
-	var files []*ast.File
+	files := make([]*ast.File, 0, len(pkgInfo.GoFiles))
 	for _, fname := range pkgInfo.GoFiles {
 		f, err := parser.ParseFile(fset, filepath.Join(pkgInfo.Dir, fname), nil, 0)
 		require.NoError(t, err)
@@ -69,7 +76,8 @@ func checkSignature(t *testing.T, pkg string, name string, expectedSignature str
 			if err != nil {
 				return nil, err
 			}
-			return os.Open(exportFile)
+
+			return os.Open(exportFile) //nolint:gosec // export file path from go list is trusted
 		}),
 	}
 	p, err := conf.Check(pkg, fset, files, nil)

--- a/godeltaprof/compat/stub_test.go
+++ b/godeltaprof/compat/stub_test.go
@@ -1,35 +1,83 @@
 package compat
 
 import (
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/importer"
+	"go/parser"
+	"go/token"
 	"go/types"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/tools/go/packages"
 )
+
+var exportFileCache sync.Map
+
+func goListExport(pkg string) (string, error) {
+	if v, ok := exportFileCache.Load(pkg); ok {
+		return v.(string), nil
+	}
+	out, err := exec.Command("go", "list", "-export", "-f", "{{.Export}}", pkg).Output()
+	if err != nil {
+		return "", fmt.Errorf("go list -export %s: %w", pkg, err)
+	}
+	path := strings.TrimSpace(string(out))
+	if path == "" {
+		return "", fmt.Errorf("no export file for %s", pkg)
+	}
+	exportFileCache.Store(pkg, path)
+	return path, nil
+}
 
 func checkSignature(t *testing.T, pkg string, name string, expectedSignature string) {
 	t.Helper()
-	cfg := &packages.Config{
-		Mode:  packages.NeedImports | packages.NeedExportFile | packages.NeedTypes | packages.NeedSyntax,
-		Tests: true,
+
+	// Use go list -json to find source files for the package.
+	// We need source (not just export data) because the functions
+	// we're checking are unexported.
+	out, err := exec.Command("go", "list", "-json", pkg).Output()
+	require.NoError(t, err, "go list -json failed for %s", pkg)
+
+	var pkgInfo struct {
+		Dir     string
+		GoFiles []string
 	}
-	pkgs, err := packages.Load(cfg, pkg)
-	require.NoError(t, err)
-	found := false
-	for _, p := range pkgs {
-		if strings.Contains(p.ID, ".test") {
-			continue
-		}
-		f := p.Types.Scope().Lookup(name)
-		if f != nil {
-			found = true
-			ff, ok := f.(*types.Func)
-			require.True(t, ok)
-			assert.Equal(t, expectedSignature, ff.String())
-		}
+	require.NoError(t, json.Unmarshal(out, &pkgInfo))
+
+	fset := token.NewFileSet()
+	var files []*ast.File
+	for _, fname := range pkgInfo.GoFiles {
+		f, err := parser.ParseFile(fset, filepath.Join(pkgInfo.Dir, fname), nil, 0)
+		require.NoError(t, err)
+		files = append(files, f)
 	}
-	assert.Truef(t, found, "function %s %s not found", pkg, name)
+
+	// Type-check the package from source.
+	// Dependencies are loaded from export data via go list -export.
+	conf := types.Config{
+		Importer: importer.ForCompiler(fset, "gc", func(path string) (io.ReadCloser, error) {
+			exportFile, err := goListExport(path)
+			if err != nil {
+				return nil, err
+			}
+			return os.Open(exportFile)
+		}),
+	}
+	p, err := conf.Check(pkg, fset, files, nil)
+	require.NoError(t, err, "type-check failed for %s", pkg)
+
+	f := p.Scope().Lookup(name)
+	require.NotNilf(t, f, "function %s not found in %s", name, pkg)
+	ff, ok := f.(*types.Func)
+	require.True(t, ok)
+	assert.Equal(t, expectedSignature, ff.String())
 }

--- a/godeltaprof/compat/stub_test.go
+++ b/godeltaprof/compat/stub_test.go
@@ -20,10 +20,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:gochecknoglobals
 var errNoExportFile = errors.New("no export file")
 
-//nolint:gochecknoglobals
 var exportFileCache = make(map[string]string)
 
 func goListExport(pkg string) (string, error) {


### PR DESCRIPTION
## Summary

Remove `golang.org/x/tools/go/packages` from `godeltaprof/compat` tests and eliminate the CI workaround that patches `go.mod` for newer Go versions.

## What changed

- **`godeltaprof/compat/stub_test.go`**: Replaced `golang.org/x/tools/go/packages` with a stdlib-only implementation using `go list -json` + `go/parser` + `go/types.Config.Check()` + `go/importer.ForCompiler`. This replicates the same pipeline that `x/tools/go/packages` runs internally — parse source files for the target package (to access unexported symbols like `runtime_FrameSymbolName`), and load dependencies from gc export data via `go list -export`.
- **`godeltaprof/compat/go.mod`**: Removed `golang.org/x/tools`, `golang.org/x/mod`, `golang.org/x/sync` dependencies.
- **`Makefile`**: Removed `gotip/fix` target and unused `GOTIP` variable.
- **`.github/workflows/go.yml`**, **`.github/workflows/gotip_cron_test.yml`**: Removed `make gotip/fix` from gotip installation steps.

## Why

`golang.org/x/tools` frequently breaks with new Go versions (especially gotip) because its internal export data reader must stay in sync with Go compiler changes. This forced a CI workaround (`make gotip/fix`) that bumps `x/tools` in `go.mod` before testing — a fragile maintenance burden tracked in #129.

The stdlib approach (`go/parser`, `go/types`, `go/importer`) uses the same Go toolchain primitives and is updated in lockstep with the compiler, so it cannot fall out of sync.

## Test plan

- [x] `go test ./godeltaprof/compat/... -run TestRuntime -v` — all 4 stub signature tests pass
- [x] `make test` — full test suite passes
- [x] No remaining `x/tools` references in `.go` files, `go.mod`, or CI configs

🤖 Generated with [Claude Code](https://claude.com/claude-code)