### PR TITLE
chore(renovate): vulnerabilities-only with allowlist

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "security:only-security-updates"
+  ],
+  "packageRules": [
+    {
+      "description": "Always update these to latest, all update types. Overrides the wildcard enabled:false from security:only-security-updates.",
+      "matchPackageNames": [
+        "golang",
+        "github.com/grafana/pyroscope-go",
+        "github.com/grafana/pyroscope-go/godeltaprof"
+      ],
+      "enabled": true
+    }
+  ]
+}


### PR DESCRIPTION
Adds a repo-level renovate.json that extends the `security:only-security-updates` preset, so renovate only opens PRs in response to OSV/GHSA advisories. An explicit allowlist re-enables routine updates for `golang` (the Docker base image used in `example/http/Dockerfile`) and the internal `grafana/pyroscope-go` modules. Modeled on grafana/pyroscope-ruby#71.