### PR TITLE
Remove pyroscope.cloud host check

### DIFF
--- a/upstream/remote/remote.go
+++ b/upstream/remote/remote.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -13,23 +12,16 @@ import (
 	"path"
 	"runtime/debug"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/grafana/pyroscope-go/upstream"
 )
 
-var errCloudTokenRequired = errors.New("please provide an authentication token." +
-	" You can find it here: https://pyroscope.io/cloud")
-
-const (
-	authTokenDeprecationWarning = "Authtoken is specified, but deprecated and ignored. " +
-		"Please switch to BasicAuthUser and BasicAuthPassword. " +
-		"If you need to use Bearer token authentication for a custom setup, " +
-		"you can use the HTTPHeaders option to set the Authorization header manually."
-	cloudHostnameSuffix = "pyroscope.cloud"
-)
+const authTokenDeprecationWarning = "Authtoken is specified, but deprecated and ignored. " +
+	"Please switch to BasicAuthUser and BasicAuthPassword. " +
+	"If you need to use Bearer token authentication for a custom setup, " +
+	"you can use the HTTPHeaders option to set the Authorization header manually."
 
 type Remote struct {
 	mu     sync.Mutex
@@ -93,17 +85,6 @@ func NewRemote(cfg Config) (*Remote, error) {
 	}
 	if cfg.HTTPClient != nil {
 		r.client = cfg.HTTPClient
-	}
-
-	// parse the upstream address
-	u, err := url.Parse(cfg.Address)
-	if err != nil {
-		return nil, err
-	}
-
-	// authorize the token first
-	if cfg.AuthToken == "" && isOGPyroscopeCloud(u) {
-		return nil, errCloudTokenRequired
 	}
 
 	return r, nil
@@ -202,8 +183,6 @@ func (r *Remote) uploadProfile(j *upstream.UploadJob) error {
 	// request.Header.Set("Content-Type", "binary/octet-stream+"+string(j.Format))
 
 	switch {
-	case r.cfg.AuthToken != "" && isOGPyroscopeCloud(u):
-		request.Header.Set("Authorization", "Bearer "+r.cfg.AuthToken)
 	case r.cfg.BasicAuthUser != "" && r.cfg.BasicAuthPassword != "":
 		request.SetBasicAuth(r.cfg.BasicAuthUser, r.cfg.BasicAuthPassword)
 	case r.cfg.AuthToken != "":
@@ -253,10 +232,6 @@ func (r *Remote) handleJobs() {
 			j.flush.Done()
 		}
 	}
-}
-
-func isOGPyroscopeCloud(u *url.URL) bool {
-	return strings.HasSuffix(u.Host, cloudHostnameSuffix)
 }
 
 // do safe upload

--- a/upstream/remote/remote_test.go
+++ b/upstream/remote/remote_test.go
@@ -27,13 +27,13 @@ func TestUploadProfile(t *testing.T) {
 		expectWarning      bool
 	}{
 		{
-			name: "OG Pyroscope Cloud with AuthToken",
+			name: "AuthToken sets Bearer header with deprecation warning",
 			cfg: Config{
 				AuthToken: "test-token",
-				Address:   "https://example.pyroscope.cloud",
+				Address:   "https://example.com",
 			},
 			expectedAuthHeader: "Bearer test-token",
-			expectWarning:      false,
+			expectWarning:      true,
 		},
 		{
 			name: "Non-OG Server with BasicAuth",


### PR DESCRIPTION
## Summary

- Removes the `errCloudTokenRequired` guard in `NewRemote` that rejected connections to `*.pyroscope.cloud` hosts without an `AuthToken`
- Removes the `isOGPyroscopeCloud` helper function and the `cloudHostnameSuffix` constant
- `AuthToken` now always triggers the deprecation warning regardless of the target host
- Updates the corresponding test case to reflect the new behaviour

---
_Generated by [Claude Code](https://claude.ai/code/session_0138PzupShS3t2owyHnY14sk)_