### PR TITLE
chore(deps): patch GO-2026-4977, drop go 1.24

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - run: make lint
 
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.24', '1.25', '1.26', 'tip']
+        go: ['1.25', '1.26', 'tip']
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/example/http/go.mod
+++ b/example/http/go.mod
@@ -1,6 +1,8 @@
 module http
 
-go 1.24.0
+go 1.25.0
+
+toolchain go1.25.10
 
 require github.com/grafana/pyroscope-go v1.3.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/grafana/pyroscope-go
 
-go 1.24.0
+go 1.25.0
+
+toolchain go1.25.10
 
 // todo can we remove this replace?
 replace github.com/grafana/pyroscope-go/godeltaprof => ./godeltaprof

--- a/godeltaprof/compat/go.mod
+++ b/godeltaprof/compat/go.mod
@@ -1,6 +1,8 @@
 module github.com/grafana/pyroscope-go/godeltaprof/compat
 
-go 1.24.0
+go 1.25.0
+
+toolchain go1.25.10
 
 replace github.com/grafana/pyroscope-go/godeltaprof => ../
 

--- a/godeltaprof/go.mod
+++ b/godeltaprof/go.mod
@@ -1,5 +1,7 @@
 module github.com/grafana/pyroscope-go/godeltaprof
 
-go 1.24.0
+go 1.25.0
+
+toolchain go1.25.10
 
 require github.com/klauspost/compress v1.18.6


### PR DESCRIPTION
https://ops.grafana-ops.net/a/grafana-vulnerabilityobs-app/projects/335/version/6228394/cve/62654574