### PR TITLE
feat: report SDK name and version as series labels

### DIFF
--- a/internal/semconv/labels.go
+++ b/internal/semconv/labels.go
@@ -3,7 +3,6 @@ package semconv
 import (
 	"runtime"
 	"runtime/debug"
-	"sync"
 
 	"github.com/grafana/pyroscope-go/internal/labelset"
 )
@@ -18,11 +17,6 @@ const (
 	scopeGodeltaprof           = "com.grafana.pyroscope/godeltaprof"
 )
 
-var (
-	scopeVersions = versions{}
-	versionOnce   = sync.Once{}
-)
-
 type versions struct {
 	sdk         string
 	godeltaprof string
@@ -34,33 +28,32 @@ type AppNames struct {
 }
 
 func getScopeVersions() versions {
-	versionOnce.Do(func() {
-		var sdk = ""
-		var godeltaprof = ""
-		info, ok := debug.ReadBuildInfo()
-		if !ok {
-			return
+	var sdk = ""
+	var godeltaprof = ""
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return versions{}
+	}
+	for _, dep := range info.Deps {
+		switch dep.Path {
+		case "github.com/grafana/pyroscope-go/godeltaprof":
+			godeltaprof = dep.Version
+		case "github.com/grafana/pyroscope-go":
+			sdk = dep.Version
 		}
-		for _, dep := range info.Deps {
-			switch dep.Path {
-			case "github.com/grafana/pyroscope-go/godeltaprof":
-				godeltaprof = dep.Version
-			case "github.com/grafana/pyroscope-go":
-				sdk = dep.Version
-			}
-		}
-		scopeVersions = versions{
-			sdk:         sdk,
-			godeltaprof: godeltaprof,
-		}
-	})
-	return scopeVersions
+	}
+
+	return versions{
+		sdk:         sdk,
+		godeltaprof: godeltaprof,
+	}
 }
 
 func getRuntimeName() string {
 	if runtime.Compiler == "gc" {
 		return "go"
 	}
+
 	return runtime.Compiler
 }
 
@@ -98,6 +91,7 @@ func MergeTagsWithAppName(appName string, sid string, tags map[string]string) (A
 	k.Add(labelProcessRuntimeName, getRuntimeName())
 	k.Add(labelProcessRuntimeVersion, getRuntimeVersion())
 	vs := getScopeVersions()
+
 	return AppNames{
 		SDK:         buildAppName(k, scopeSDK, vs.sdk),
 		Godeltaprof: buildAppName(k, scopeGodeltaprof, vs.godeltaprof),
@@ -111,5 +105,6 @@ func buildAppName(builder *labelset.LabelSet, scope, version string) string {
 	} else {
 		builder.Add(labelScopeVersion, "") // delete
 	}
+
 	return builder.Normalized()
 }

--- a/internal/semconv/labels.go
+++ b/internal/semconv/labels.go
@@ -1,0 +1,115 @@
+package semconv
+
+import (
+	"runtime"
+	"runtime/debug"
+	"sync"
+
+	"github.com/grafana/pyroscope-go/internal/labelset"
+)
+
+const (
+	labelScopeName             = "otel.scope.name"
+	labelScopeVersion          = "otel.scope.version"
+	labelProcessRuntimeName    = "process.runtime.name"
+	labelProcessRuntimeVersion = "process.runtime.version"
+	labelPyroscopeSessionID    = "__session_id__"
+	scopeSDK                   = "com.grafana.pyroscope/go"
+	scopeGodeltaprof           = "com.grafana.pyroscope/godeltaprof"
+)
+
+var (
+	scopeVersions = versions{}
+	versionOnce   = sync.Once{}
+)
+
+type versions struct {
+	sdk         string
+	godeltaprof string
+}
+
+type AppNames struct {
+	SDK         string
+	Godeltaprof string
+}
+
+func getScopeVersions() versions {
+	versionOnce.Do(func() {
+		var sdk = ""
+		var godeltaprof = ""
+		info, ok := debug.ReadBuildInfo()
+		if !ok {
+			return
+		}
+		for _, dep := range info.Deps {
+			switch dep.Path {
+			case "github.com/grafana/pyroscope-go/godeltaprof":
+				godeltaprof = dep.Version
+			case "github.com/grafana/pyroscope-go":
+				sdk = dep.Version
+			}
+		}
+		scopeVersions = versions{
+			sdk:         sdk,
+			godeltaprof: godeltaprof,
+		}
+	})
+	return scopeVersions
+}
+
+func getRuntimeName() string {
+	if runtime.Compiler == "gc" {
+		return "go"
+	}
+	return runtime.Compiler
+}
+
+func getRuntimeVersion() string {
+	return runtime.Version()
+}
+
+// MergeTagsWithAppName validates user input and merges explicitly specified
+// tags with tags from app name.
+//
+// App name may be in the full form including tags (app.name{foo=bar,baz=qux}).
+// Returned application name is always short, any tags that were included are
+// moved to tags map. When merged with explicitly provided tags (config/CLI),
+// last take precedence.
+//
+// App name may be an empty string. Tags must not contain reserved keys,
+// the map is modified in place.
+func MergeTagsWithAppName(appName string, sid string, tags map[string]string) (AppNames, error) {
+	k, err := labelset.Parse(appName)
+	if err != nil {
+		return AppNames{}, err
+	}
+	for tagKey, tagValue := range tags {
+		if labelset.IsLabelNameReserved(tagKey) {
+			continue
+		}
+		err = labelset.ValidateLabelName(tagKey)
+		if err != nil {
+			return AppNames{}, err
+		}
+		k.Add(tagKey, tagValue)
+	}
+
+	k.Add(labelPyroscopeSessionID, sid)
+	k.Add(labelProcessRuntimeName, getRuntimeName())
+	k.Add(labelProcessRuntimeVersion, getRuntimeVersion())
+	vs := getScopeVersions()
+	return AppNames{
+		SDK:         buildAppName(k, scopeSDK, vs.sdk),
+		Godeltaprof: buildAppName(k, scopeGodeltaprof, vs.godeltaprof),
+	}, nil
+}
+
+func buildAppName(builder *labelset.LabelSet, scope, version string) string {
+	builder.Add(labelScopeName, scope)
+	if version != "" {
+		builder.Add(labelScopeVersion, version)
+	} else {
+		builder.Add(labelScopeVersion, "") // delete
+	}
+	return builder.Normalized()
+}

--- a/internal/semconv/labels_test.go
+++ b/internal/semconv/labels_test.go
@@ -1,0 +1,20 @@
+package semconv
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMergeTagsWithAppName(t *testing.T) {
+	tags := map[string]string{"foo": "bar"}
+	names, err := MergeTagsWithAppName("testAppapp", "239", tags)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(names.SDK, "testAppapp{__session_id__=239,foo=bar,otel.scope.name=com.grafana.pyroscope/go,process.runtime.name=go,process.runtime.version=") {
+		t.Fatalf("unexpected sdk name %s", names.SDK)
+	}
+	if !strings.HasPrefix(names.Godeltaprof, "testAppapp{__session_id__=239,foo=bar,otel.scope.name=com.grafana.pyroscope/godeltaprof,process.runtime.name=go,process.runtime.version=") {
+		t.Fatalf("unexpected godeltaprof name %s", names.Godeltaprof)
+	}
+}

--- a/internal/semconv/labels_test.go
+++ b/internal/semconv/labels_test.go
@@ -11,10 +11,10 @@ func TestMergeTagsWithAppName(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.HasPrefix(names.SDK, "testAppapp{__session_id__=239,foo=bar,otel.scope.name=com.grafana.pyroscope/go,process.runtime.name=go,process.runtime.version=") {
+	if !strings.HasPrefix(names.SDK, "testAppapp{__session_id__=239,foo=bar,otel.scope.name=com.grafana.pyroscope/go,process.runtime.name=go,process.runtime.version=") { //nolint:lll
 		t.Fatalf("unexpected sdk name %s", names.SDK)
 	}
-	if !strings.HasPrefix(names.Godeltaprof, "testAppapp{__session_id__=239,foo=bar,otel.scope.name=com.grafana.pyroscope/godeltaprof,process.runtime.name=go,process.runtime.version=") {
+	if !strings.HasPrefix(names.Godeltaprof, "testAppapp{__session_id__=239,foo=bar,otel.scope.name=com.grafana.pyroscope/godeltaprof,process.runtime.name=go,process.runtime.version=") { //nolint:lll
 		t.Fatalf("unexpected godeltaprof name %s", names.Godeltaprof)
 	}
 }

--- a/session.go
+++ b/session.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/grafana/pyroscope-go/godeltaprof"
-	"github.com/grafana/pyroscope-go/internal/labelset"
+	"github.com/grafana/pyroscope-go/internal/semconv"
 	"github.com/grafana/pyroscope-go/upstream"
 )
 
@@ -38,7 +38,7 @@ type Session struct {
 	blockBuf         *bytes.Buffer
 
 	lastGCGeneration uint32
-	appName          string
+	appNames         semconv.AppNames
 	startTime        time.Time
 
 	deltaBlock *godeltaprof.BlockProfiler
@@ -89,7 +89,7 @@ func NewSession(c SessionConfig) (*Session, error) {
 		c.UploadRate = math.MaxInt64
 	}
 
-	appName, err := mergeTagsWithAppName(c.AppName, newSessionID(), c.Tags)
+	appNames, err := semconv.MergeTagsWithAppName(c.AppName, newSessionID().String(), c.Tags)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func NewSession(c SessionConfig) (*Session, error) {
 
 	ps := &Session{
 		upstream:         c.Upstream,
-		appName:          appName,
+		appNames:         appNames,
 		profileTypes:     c.ProfilingTypes,
 		disableGCRuns:    c.DisableGCRuns,
 		uploadRate:       c.UploadRate,
@@ -125,40 +125,10 @@ func NewSession(c SessionConfig) (*Session, error) {
 		deltaBlock: godeltaprof.NewBlockProfiler(),
 		deltaMutex: godeltaprof.NewMutexProfiler(),
 		deltaHeap:  godeltaprof.NewHeapProfiler(),
-		cpu:        newCPUProfileCollector(appName, c.Upstream, c.Logger, c.UploadRate),
+		cpu:        newCPUProfileCollector(appNames.SDK, c.Upstream, c.Logger, c.UploadRate),
 	}
 
 	return ps, nil
-}
-
-// mergeTagsWithAppName validates user input and merges explicitly specified
-// tags with tags from app name.
-//
-// App name may be in the full form including tags (app.name{foo=bar,baz=qux}).
-// Returned application name is always short, any tags that were included are
-// moved to tags map. When merged with explicitly provided tags (config/CLI),
-// last take precedence.
-//
-// App name may be an empty string. Tags must not contain reserved keys,
-// the map is modified in place.
-func mergeTagsWithAppName(appName string, sid sessionID, tags map[string]string) (string, error) {
-	k, err := labelset.Parse(appName)
-	if err != nil {
-		return "", err
-	}
-	for tagKey, tagValue := range tags {
-		if labelset.IsLabelNameReserved(tagKey) {
-			continue
-		}
-		err = labelset.ValidateLabelName(tagKey)
-		if err != nil {
-			return "", err
-		}
-		k.Add(tagKey, tagValue)
-	}
-	k.Add(sessionIDLabelName, sid.String())
-
-	return k.Normalized(), nil
 }
 
 // revive:disable-next-line:cognitive-complexity complexity is fine
@@ -294,7 +264,7 @@ func (ps *Session) uploadData(startTime, endTime time.Time) {
 				return
 			}
 			ps.upstream.Upload(&upstream.UploadJob{
-				Name:            ps.appName,
+				Name:            ps.appNames.SDK,
 				StartTime:       startTime,
 				EndTime:         endTime,
 				SpyName:         "gospy",
@@ -324,7 +294,7 @@ func (ps *Session) uploadData(startTime, endTime time.Time) {
 				return
 			}
 			ps.upstream.Upload(&upstream.UploadJob{
-				Name:             ps.appName,
+				Name:             ps.appNames.SDK,
 				StartTime:        startTime,
 				EndTime:          endTime,
 				SpyName:          "gospy",
@@ -373,7 +343,7 @@ func (ps *Session) dumpHeapProfile(startTime time.Time, endTime time.Time) {
 		}
 		curMemBytes := copyBuf(ps.memBuf.Bytes())
 		job := &upstream.UploadJob{
-			Name:             ps.appName,
+			Name:             ps.appNames.Godeltaprof,
 			StartTime:        startTime,
 			EndTime:          endTime,
 			SpyName:          "gospy",
@@ -402,7 +372,7 @@ func (ps *Session) dumpMutexProfile(startTime time.Time, endTime time.Time) {
 	}
 	curMutexBuf := copyBuf(ps.mutexBuf.Bytes())
 	job := &upstream.UploadJob{
-		Name:             ps.appName,
+		Name:             ps.appNames.Godeltaprof,
 		StartTime:        startTime,
 		EndTime:          endTime,
 		SpyName:          "gospy",
@@ -428,7 +398,7 @@ func (ps *Session) dumpBlockProfile(startTime time.Time, endTime time.Time) {
 	}
 	curBlockBuf := copyBuf(ps.blockBuf.Bytes())
 	job := &upstream.UploadJob{
-		Name:             ps.appName,
+		Name:             ps.appNames.Godeltaprof,
 		StartTime:        startTime,
 		EndTime:          endTime,
 		SpyName:          "gospy",

--- a/session_id.go
+++ b/session_id.go
@@ -10,8 +10,6 @@ import (
 	"sync"
 )
 
-const sessionIDLabelName = "__session_id__"
-
 type sessionID uint64
 
 func (s sessionID) String() string {


### PR DESCRIPTION

Add `otel.scope.name`, `otel.scope.version`, `process.runtime.name`, `process.runtime.version` labels.

Labels `otel.scope.name`, `otel.scope.version` differ for godeltaprof and other profiles with `com.grafana.pyroscope/go` and `com.grafana.pyroscope/godeltaprof` and corresponding versions.
