### PR TITLE
ci: pin go 1.26 for gotip bootstrap

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,7 +58,9 @@ jobs:
         if: matrix.go == 'tip'
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: 1.x
+          # Go tip requires go >= 1.26 as bootstrap toolchain; 1.x resolves to
+          # an older cached version on self-hosted runners (check-latest is false)
+          go-version: '1.26'
 
       - name: Install Go tip
         shell: bash


### PR DESCRIPTION
The `go (tip)` job has been failing on every PR since ~July 21:

```
Building Go toolchain1 using /opt/hostedtoolcache/go/1.25.9/x64.
go: downloading go1.26.0 (linux/amd64)
go: download go1.26.0 for linux/amd64: toolchain not available
go tool dist: FAILED
gotip: failed to build go: exit status 1
```